### PR TITLE
Fix issue with incomplete keyword at the end of the sentence

### DIFF
--- a/flashtext/keyword.py
+++ b/flashtext/keyword.py
@@ -670,5 +670,7 @@ class KeywordProcessor(object):
                 if self._keyword in current_dict:
                     sequence_found = current_dict[self._keyword]
                     new_sentence += sequence_found
+                else:
+                    new_sentence += current_word
             idx += 1
         return new_sentence

--- a/test/keyword_extractor_test_cases.json
+++ b/test/keyword_extractor_test_cases.json
@@ -9,6 +9,15 @@
         "keywords_case_sensitive": ["Python"]
     },
     {
+        "sentence": "I like python",
+        "keyword_dict": {
+            "Pythonizer": ["pythonizer"]
+        },
+        "explanation": "Incomplete keyword at the end of the sentence.",
+        "keywords": [],
+        "keywords_case_sensitive": []
+    },
+    {
         "sentence": "python I like",
         "keyword_dict": {
             "Python": ["python"]


### PR DESCRIPTION
While experimenting with the Flashtext performance, I've added exact check between the replacement results by different methods.
By doing that, I've noticed that if the sentence ends with beginning of some keyword, that last word of sentence would be lost.