### PR TITLE
internationalize word boundary checks

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,4 @@
 [run]
-omit = test/*
+omit = 
+    test/*
+    setup.py

--- a/README.rst
+++ b/README.rst
@@ -69,12 +69,12 @@ Case Sensitive example
 
 Span of keywords extracted
     >>> from flashtext import KeywordProcessor
-    >>> keyword_processor = KeywordProcessor(case_sensitive=True)
+    >>> keyword_processor = KeywordProcessor()
     >>> keyword_processor.add_keyword('Big Apple', 'New York')
     >>> keyword_processor.add_keyword('Bay Area')
     >>> keywords_found = keyword_processor.extract_keywords('I love big Apple and Bay Area.', span_info=True)
     >>> keywords_found
-    >>> # [('Bay Area', 21, 29)]
+    >>> # [('New York', 7, 16), ('Bay Area', 21, 29)]
 
 No clean name for Keywords
     >>> from flashtext import KeywordProcessor

--- a/README.rst
+++ b/README.rst
@@ -134,9 +134,9 @@ Get all keywords in dictionary
     >>> from flashtext import KeywordProcessor
     >>> keyword_processor = KeywordProcessor()
     >>> keyword_processor.add_keyword('j2ee', 'Java')
-    >>> keyword_processor.add_keyword('onGoing', 'rendom')
+    >>> keyword_processor.add_keyword('colour', 'color')
     >>> keyword_processor.get_all_keywords()
-    >>> # output: {'j2ee': 'Java', 'ongoing': 'rendom'}
+    >>> # output: {'colour': 'color', 'j2ee': 'Java'}
 
 For detecting Word Boundary currently any character other than this `\\w` `[A-Za-z0-9_]` is considered a word boundary.
 

--- a/README.rst
+++ b/README.rst
@@ -199,8 +199,27 @@ The idea for this library came from the following `StackOverflow question
 <https://stackoverflow.com/questions/44178449/regex-replace-is-taking-time-for-millions-of-documents-how-to-make-it-faster>`_.
 
 
-References
+Citation
 ----------
+
+The original paper published on `FlashText algorithm <https://arxiv.org/abs/1711.00046>`_.
+
+::
+
+    @ARTICLE{2017arXiv171100046S,
+       author = {{Singh}, V.},
+        title = "{Replace or Retrieve Keywords In Documents at Scale}",
+      journal = {ArXiv e-prints},
+    archivePrefix = "arXiv",
+       eprint = {1711.00046},
+     primaryClass = "cs.DS",
+     keywords = {Computer Science - Data Structures and Algorithms},
+         year = 2017,
+        month = oct,
+       adsurl = {http://adsabs.harvard.edu/abs/2017arXiv171100046S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+    }
+
 
 The original paper published on `FlashText algorithm <https://arxiv.org/abs/1711.00046>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,15 @@ Case Sensitive example
     >>> keywords_found
     >>> # ['Bay Area']
 
+Span of keywords extracted
+    >>> from flashtext import KeywordProcessor
+    >>> keyword_processor = KeywordProcessor(case_sensitive=True)
+    >>> keyword_processor.add_keyword('Big Apple', 'New York')
+    >>> keyword_processor.add_keyword('Bay Area')
+    >>> keywords_found = keyword_processor.extract_keywords('I love big Apple and Bay Area.', span_info=True)
+    >>> keywords_found
+    >>> # [('Bay Area', 21, 29)]
+
 No clean name for Keywords
     >>> from flashtext import KeywordProcessor
     >>> keyword_processor = KeywordProcessor()

--- a/README.rst
+++ b/README.rst
@@ -220,9 +220,6 @@ The original paper published on `FlashText algorithm <https://arxiv.org/abs/1711
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
     }
 
-
-The original paper published on `FlashText algorithm <https://arxiv.org/abs/1711.00046>`_.
-
 The article published on `Medium freeCodeCamp <https://medium.freecodecamp.org/regex-was-taking-5-days-flashtext-does-it-in-15-minutes-55f04411025f>`_.
 
 

--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,15 @@ Span of keywords extracted
     >>> keywords_found
     >>> # [('New York', 7, 16), ('Bay Area', 21, 29)]
 
+Get Extra information with keywords extracted
+    >>> from flashtext import KeywordProcessor
+    >>> kp = KeywordProcessor()
+    >>> kp.add_keyword('Taj Mahal', ('Monument', 'Taj Mahal'))
+    >>> kp.add_keyword('Delhi', ('Location', 'Delhi'))
+    >>> kp.extract_keywords('Taj Mahal is in Delhi.')
+    >>> # [('Monument', 'Taj Mahal'), ('Location', 'Delhi')]
+    >>> # NOTE: replace_keywords feature won't work with this.
+
 No clean name for Keywords
     >>> from flashtext import KeywordProcessor
     >>> keyword_processor = KeywordProcessor()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,12 +66,12 @@ Case Sensitive example
 
 Span of keywords extracted
     >>> from flashtext import KeywordProcessor
-    >>> keyword_processor = KeywordProcessor(case_sensitive=True)
+    >>> keyword_processor = KeywordProcessor()
     >>> keyword_processor.add_keyword('Big Apple', 'New York')
     >>> keyword_processor.add_keyword('Bay Area')
     >>> keywords_found = keyword_processor.extract_keywords('I love big Apple and Bay Area.', span_info=True)
     >>> keywords_found
-    >>> # [('Bay Area', 21, 29)]
+    >>> # [('New York', 7, 16), ('Bay Area', 21, 29)]
 
 No clean name for Keywords
     >>> from flashtext import KeywordProcessor

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -228,9 +228,6 @@ The original paper published on `FlashText algorithm <https://arxiv.org/abs/1711
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
     }
 
-
-The original paper published on `FlashText algorithm <https://arxiv.org/abs/1711.00046>`_.
-
 The article published on `Medium freeCodeCamp <https://medium.freecodecamp.org/regex-was-taking-5-days-flashtext-does-it-in-15-minutes-55f04411025f>`_.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -131,9 +131,9 @@ Get all keywords in dictionary
     >>> from flashtext import KeywordProcessor
     >>> keyword_processor = KeywordProcessor()
     >>> keyword_processor.add_keyword('j2ee', 'Java')
-    >>> keyword_processor.add_keyword('onGoing', 'rendom')
+    >>> keyword_processor.add_keyword('colour', 'color')
     >>> keyword_processor.get_all_keywords()
-    >>> # output: {'j2ee': 'Java', 'ongoing': 'rendom'}
+    >>> # output: {'colour': 'color', 'j2ee': 'Java'}
 
 For detecting Word Boundary currently any character other than this `\\w` `[A-Za-z0-9_]` is considered a word boundary.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,6 +73,15 @@ Span of keywords extracted
     >>> keywords_found
     >>> # [('New York', 7, 16), ('Bay Area', 21, 29)]
 
+Get Extra information with keywords extracted
+    >>> from flashtext import KeywordProcessor
+    >>> kp = KeywordProcessor()
+    >>> kp.add_keyword('Taj Mahal', ('Monument', 'Taj Mahal'))
+    >>> kp.add_keyword('Delhi', ('Location', 'Delhi'))
+    >>> kp.extract_keywords('Taj Mahal is in Delhi.')
+    >>> # [('Monument', 'Taj Mahal'), ('Location', 'Delhi')]
+    >>> # NOTE: replace_keywords feature won't work with this.
+
 No clean name for Keywords
     >>> from flashtext import KeywordProcessor
     >>> keyword_processor = KeywordProcessor()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -207,8 +207,27 @@ The idea for this library came from the following `StackOverflow question
 <https://stackoverflow.com/questions/44178449/regex-replace-is-taking-time-for-millions-of-documents-how-to-make-it-faster>`_.
 
 
-References
+Citation
 ----------
+
+The original paper published on `FlashText algorithm <https://arxiv.org/abs/1711.00046>`_.
+
+::
+
+    @ARTICLE{2017arXiv171100046S,
+       author = {{Singh}, V.},
+        title = "{Replace or Retrieve Keywords In Documents at Scale}",
+      journal = {ArXiv e-prints},
+    archivePrefix = "arXiv",
+       eprint = {1711.00046},
+     primaryClass = "cs.DS",
+     keywords = {Computer Science - Data Structures and Algorithms},
+         year = 2017,
+        month = oct,
+       adsurl = {http://adsabs.harvard.edu/abs/2017arXiv171100046S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+    }
+
 
 The original paper published on `FlashText algorithm <https://arxiv.org/abs/1711.00046>`_.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,6 +64,15 @@ Case Sensitive example
     >>> keywords_found
     >>> # ['Bay Area']
 
+Span of keywords extracted
+    >>> from flashtext import KeywordProcessor
+    >>> keyword_processor = KeywordProcessor(case_sensitive=True)
+    >>> keyword_processor.add_keyword('Big Apple', 'New York')
+    >>> keyword_processor.add_keyword('Bay Area')
+    >>> keywords_found = keyword_processor.extract_keywords('I love big Apple and Bay Area.', span_info=True)
+    >>> keywords_found
+    >>> # [('Bay Area', 21, 29)]
+
 No clean name for Keywords
     >>> from flashtext import KeywordProcessor
     >>> keyword_processor = KeywordProcessor()

--- a/flashtext/keyword.py
+++ b/flashtext/keyword.py
@@ -289,6 +289,7 @@ class KeywordProcessor(object):
 
         Args:
             keyword_file : path to keywords file
+            encoding : specify the encoding of the file
 
         Examples:
             keywords file format can be like:

--- a/flashtext/keyword.py
+++ b/flashtext/keyword.py
@@ -174,8 +174,12 @@ class KeywordProcessor(object):
                 if letter in current_dict:
                     character_trie_list.append((letter, current_dict))
                     current_dict = current_dict[letter]
+                else:
+                    # if character is not found, break out of the loop
+                    current_dict = None
+                    break
             # remove the characters from trie dict if there are no other keywords with them
-            if self._keyword in current_dict:
+            if current_dict and self._keyword in current_dict:
                 # we found a complete match for input keyword.
                 character_trie_list.append((self._keyword, current_dict))
                 character_trie_list.reverse()

--- a/flashtext/keyword.py
+++ b/flashtext/keyword.py
@@ -173,7 +173,7 @@ class KeywordProcessor(object):
                 if letter in current_dict:
                     character_trie_list.append((letter, current_dict))
                     current_dict = current_dict[letter]
-            # remove the charactes from trie dict if there are no other keywords with them
+            # remove the characters from trie dict if there are no other keywords with them
             if self._keyword in current_dict:
                 # we found a complete match for input keyword.
                 character_trie_list.append((self._keyword, current_dict))
@@ -410,7 +410,7 @@ class KeywordProcessor(object):
 
         Args:
             term_so_far : string
-                term built so far by adding all previous charactes
+                term built so far by adding all previous characters
             current_dict : dict
                 current recursive position in dictionary
 

--- a/flashtext/keyword.py
+++ b/flashtext/keyword.py
@@ -1,5 +1,6 @@
 import os
 import string
+import io
 
 
 class KeywordProcessor(object):
@@ -283,7 +284,7 @@ class KeywordProcessor(object):
         """
         return self.__getitem__(word)
 
-    def add_keyword_from_file(self, keyword_file):
+    def add_keyword_from_file(self, keyword_file, encoding="utf-8"):
         """To add keywords from a file
 
         Args:
@@ -311,7 +312,7 @@ class KeywordProcessor(object):
         """
         if not os.path.isfile(keyword_file):
             raise IOError("Invalid file path {}".format(keyword_file))
-        with open(keyword_file)as f:
+        with io.open(keyword_file, encoding=encoding) as f:
             for line in f:
                 if '=>' in line:
                     keyword, clean_name = line.split('=>')

--- a/flashtext/keyword.py
+++ b/flashtext/keyword.py
@@ -670,5 +670,7 @@ class KeywordProcessor(object):
                 if self._keyword in current_dict:
                     sequence_found = current_dict[self._keyword]
                     new_sentence += sequence_found
+                else:
+                    new_sentence += current_word
             idx += 1
         return new_sentence

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ class PyTest(Command):
         raise SystemExit(errno)
 
 name = 'flashtext'
-version = '2.5'
+version = '2.7'
 
 cmdclass = {'test': PyTest}
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ class PyTest(Command):
         raise SystemExit(errno)
 
 name = 'flashtext'
-version = '2.4'
+version = '2.5'
 
 cmdclass = {'test': PyTest}
 

--- a/test/keyword_extractor_test_cases.json
+++ b/test/keyword_extractor_test_cases.json
@@ -4,7 +4,7 @@
         "keyword_dict": {
             "Python": ["python"]
         },
-        "explaination": "Keyword at the end of the sentence.",
+        "explanation": "Keyword at the end of the sentence.",
         "keywords": ["Python"],
         "keywords_case_sensitive": ["Python"]
     },
@@ -13,7 +13,7 @@
         "keyword_dict": {
             "Python": ["python"]
         },
-        "explaination": "Keyword at the beginning of the sentence.",
+        "explanation": "Keyword at the beginning of the sentence.",
         "keywords": ["Python"],
         "keywords_case_sensitive": ["Python"]
     },
@@ -22,7 +22,7 @@
         "keyword_dict": {
             "Python": ["python"]
         },
-        "explaination": "Keyword before the end of the sentence.",
+        "explanation": "Keyword before the end of the sentence.",
         "keywords": ["Python"],
         "keywords_case_sensitive": ["Python"]
     },
@@ -32,7 +32,7 @@
             "Python": ["python"],
             "Java": ["java"]
         },
-        "explaination": "Multiple keywords in the end of the sentence.",
+        "explanation": "Multiple keywords in the end of the sentence.",
         "keywords": ["Python", "Java"],
         "keywords_case_sensitive": ["Python", "Java"]
     },
@@ -42,7 +42,7 @@
             "Python": ["python"],
             "Java": ["java"]
         },
-        "explaination": "Multiple keywords in the sentence with other word in between.",
+        "explanation": "Multiple keywords in the sentence with other word in between.",
         "keywords": ["Python", "Java"],
         "keywords_case_sensitive": ["Python", "Java"]
     },
@@ -51,7 +51,7 @@
         "keyword_dict": {
             "Python": ["python"]
         },
-        "explaination": "Single keyword in the sentence.",
+        "explanation": "Single keyword in the sentence.",
         "keywords": ["Python"],
         "keywords_case_sensitive": ["Python"]
     },
@@ -60,7 +60,7 @@
         "keyword_dict": {
             "Python": ["python"]
         },
-        "explaination": "Single keyword in the sentence with space prefix.",
+        "explanation": "Single keyword in the sentence with space prefix.",
         "keywords": ["Python"],
         "keywords_case_sensitive": ["Python"]
     },
@@ -69,7 +69,7 @@
         "keyword_dict": {
             "R": ["r"]
         },
-        "explaination": "Single char keyword at the end of the sentence.",
+        "explanation": "Single char keyword at the end of the sentence.",
         "keywords": ["R"],
         "keywords_case_sensitive": ["R"]
     },
@@ -78,7 +78,7 @@
         "keyword_dict": {
             "R": ["r"]
         },
-        "explaination": "Single char keyword at the beginning of the sentence.",
+        "explanation": "Single char keyword at the beginning of the sentence.",
         "keywords": ["R"],
         "keywords_case_sensitive": ["R"]
     },
@@ -87,7 +87,7 @@
         "keyword_dict": {
             "R": ["r"]
         },
-        "explaination": "Single char keyword before the end of the sentence.",
+        "explanation": "Single char keyword before the end of the sentence.",
         "keywords": ["R"],
         "keywords_case_sensitive": []
     },
@@ -97,7 +97,7 @@
             "R": ["r"],
             "Java": ["java"]
         },
-        "explaination": "Multiple keywords in the end of the sentence.",
+        "explanation": "Multiple keywords in the end of the sentence.",
         "keywords": ["R", "Java"],
         "keywords_case_sensitive": ["Java"]
     },
@@ -107,7 +107,7 @@
             "R": ["R"],
             "Java": ["java"]
         },
-        "explaination": "Multiple keywords in the sentence with other word in between.",
+        "explanation": "Multiple keywords in the sentence with other word in between.",
         "keywords": ["R", "Java"],
         "keywords_case_sensitive": ["R", "Java"]
     },
@@ -116,7 +116,7 @@
         "keyword_dict": {
             "R": ["r"]
         },
-        "explaination": "Single character keyword in the sentence.",
+        "explanation": "Single character keyword in the sentence.",
         "keywords": ["R"],
         "keywords_case_sensitive": []
     },
@@ -125,7 +125,7 @@
         "keyword_dict": {
             "R": ["R"]
         },
-        "explaination": "Single character keyword in the sentence with space prefix.",
+        "explanation": "Single character keyword in the sentence with space prefix.",
         "keywords": ["R"],
         "keywords_case_sensitive": ["R"]
     },
@@ -134,7 +134,7 @@
         "keyword_dict": {
             "Distributed Super Computing": ["distributed super computing"]
         },
-        "explaination": "Multi word Keyword at the end of the sentence.",
+        "explanation": "Multi word Keyword at the end of the sentence.",
         "keywords": ["Distributed Super Computing"],
         "keywords_case_sensitive": ["Distributed Super Computing"]
     },
@@ -143,7 +143,7 @@
         "keyword_dict": {
             "Distributed Super Computing": ["distributed super computing"]
         },
-        "explaination": "Multi word Keyword at the beginning of the sentence.",
+        "explanation": "Multi word Keyword at the beginning of the sentence.",
         "keywords": ["Distributed Super Computing"],
         "keywords_case_sensitive": ["Distributed Super Computing"]
     },
@@ -152,7 +152,7 @@
         "keyword_dict": {
             "Distributed Super Computing": ["distributed super computing"]
         },
-        "explaination": "Multi word Keyword before the end of the sentence.",
+        "explanation": "Multi word Keyword before the end of the sentence.",
         "keywords": ["Distributed Super Computing"],
         "keywords_case_sensitive": ["Distributed Super Computing"]
     },
@@ -162,7 +162,7 @@
             "Distributed Super Computing": ["distributed super computing"],
             "Java": ["java"]
         },
-        "explaination": "Multi word Keyword at the end of the sentence.",
+        "explanation": "Multi word Keyword at the end of the sentence.",
         "keywords": ["Distributed Super Computing", "Java"],
         "keywords_case_sensitive": ["Distributed Super Computing", "Java"]
     },
@@ -172,7 +172,7 @@
             "Distributed Super Computing": ["distributed super computing"],
             "Java": ["java programing"]
         },
-        "explaination": "Multiple Multi word Keyword at the end of the sentence.",
+        "explanation": "Multiple Multi word Keyword at the end of the sentence.",
         "keywords": ["Distributed Super Computing", "Java"],
         "keywords_case_sensitive": ["Distributed Super Computing", "Java"]
     },
@@ -182,7 +182,7 @@
             "Distributed Super Computing": ["distributed super computing"],
             "Java": ["java"]
         },
-        "explaination": "Multiple keywords in the sentence with other word in between.",
+        "explanation": "Multiple keywords in the sentence with other word in between.",
         "keywords": ["Distributed Super Computing", "Java"],
         "keywords_case_sensitive": ["Distributed Super Computing", "Java"]
     },
@@ -191,7 +191,7 @@
         "keyword_dict": {
             "Distributed Super Computing": ["distributed super computing"]
         },
-        "explaination": "Single Multi word Keyword in the sentence.",
+        "explanation": "Single Multi word Keyword in the sentence.",
         "keywords": ["Distributed Super Computing"],
         "keywords_case_sensitive": ["Distributed Super Computing"]
     },
@@ -200,7 +200,7 @@
         "keyword_dict": {
             "Distributed Super Computing": ["distributed super computing"]
         },
-        "explaination": "Single Multi word Keyword in the sentence with space prefix.",
+        "explanation": "Single Multi word Keyword in the sentence with space prefix.",
         "keywords": ["Distributed Super Computing"],
         "keywords_case_sensitive": ["Distributed Super Computing"]
     },
@@ -209,7 +209,7 @@
         "keyword_dict": {
             "Distributed Super Computing": ["distributed super computing"]
         },
-        "explaination": "Multi word Keyword twice",
+        "explanation": "Multi word Keyword twice",
         "keywords": ["Distributed Super Computing", "Distributed Super Computing"],
         "keywords_case_sensitive": ["Distributed Super Computing", "Distributed Super Computing"]
     },
@@ -218,7 +218,7 @@
         "keyword_dict": {
             "Distributed Super Computing": ["distributed super computing"]
         },
-        "explaination": "Multi word Keyword partial then complete.",
+        "explanation": "Multi word Keyword partial then complete.",
         "keywords": ["Distributed Super Computing"],
         "keywords_case_sensitive": ["Distributed Super Computing"]
     },
@@ -228,7 +228,7 @@
             "Distributed Super Computing": ["distributed super computing"],
             "Java": ["java"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computing", "Java"],
         "keywords_case_sensitive": ["Distributed Super Computing", "Java"]
     },
@@ -238,7 +238,7 @@
             "Distributed Super Computing": ["distributed super computing"],
             "Distributed Super Computing Institute": ["distributed super computing institute"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computing Institute"],
         "keywords_case_sensitive": ["Distributed Super Computing Institute"]
     },
@@ -248,7 +248,7 @@
             "Distributed Super Computing": ["distributed super computing"],
             "Distributed Super Computing Institute": ["distributed super computing institute"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computing"],
         "keywords_case_sensitive": ["Distributed Super Computing"]
     },
@@ -259,7 +259,7 @@
             "Distributed Super Computing Institute": ["distributed super computing institute"],
             "Java": ["java"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computing", "Java"],
         "keywords_case_sensitive": ["Distributed Super Computing", "Java"]
     },
@@ -270,7 +270,7 @@
             "Distributed Super Computing Institute": ["distributed super computing institute"],
             "Java": ["java"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computing Institute", "Java"],
         "keywords_case_sensitive": ["Distributed Super Computing Institute", "Java"]
     },
@@ -281,7 +281,7 @@
             "Distributed Super Computing Institute": ["distributed super computing institute"],
             "Java": ["java"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computing Institute", "Java"],
         "keywords_case_sensitive": ["Distributed Super Computing Institute", "Java"]
     },
@@ -292,7 +292,7 @@
             "Distributed Super Computing Institute": ["distributed super computing institute"],
             "R": ["r"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computing", "R"],
         "keywords_case_sensitive": ["Distributed Super Computing", "R"]
     },
@@ -303,7 +303,7 @@
             "Distributed Super Computing Institute": ["distributed super computing institute"],
             "R": ["r"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computing Institute", "R"],
         "keywords_case_sensitive": ["Distributed Super Computing Institute", "R"]
     },
@@ -314,7 +314,7 @@
             "Distributed Super Computing Institute": ["distributed super computing institute"],
             "R": ["r"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computing Institute", "R"],
         "keywords_case_sensitive": ["Distributed Super Computing Institute", "R"]
     },
@@ -324,7 +324,7 @@
             "Distributed Programing": ["distributed programing"],
             "Pronoun Game": ["pronoun game"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Pronoun Game"],
         "keywords_case_sensitive": ["Pronoun Game"]
     },
@@ -334,7 +334,7 @@
             "Distributed Super Computer": ["distributed super computer"],
             "Computer Game": ["computer game"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computer"],
         "keywords_case_sensitive": ["Distributed Super Computer"]
     },
@@ -344,7 +344,7 @@
             "Distributed Super Company": ["distributed super company"],
             "Computer Game": ["computer game"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Computer Game"],
         "keywords_case_sensitive": ["Computer Game"]
     },
@@ -355,7 +355,7 @@
             "Super Computer": ["super computer"],
             "Computer Game": ["computer game"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Super Computer"],
         "keywords_case_sensitive": ["Super Computer"]
     },
@@ -366,7 +366,7 @@
             "Super Computer": ["super computer"],
             "Computer Game": ["computer game"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": [],
         "keywords_case_sensitive": []
     },
@@ -376,7 +376,7 @@
             "Computer Game": ["computer game"],
             "Computer Game Development": ["computer game development"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Computer Game Development"],
         "keywords_case_sensitive": ["Computer Game Development"]
     },
@@ -386,7 +386,7 @@
             "Computer Gaming": ["computer gaming"],
             "Computer Game Development": ["computer game development"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Computer Game Development"],
         "keywords_case_sensitive": ["Computer Game Development"]
     },
@@ -395,7 +395,7 @@
         "keyword_dict": {
             ".NET": [".net"]
         },
-        "explaination": "keyword with special character",
+        "explanation": "keyword with special character",
         "keywords": [".NET"],
         "keywords_case_sensitive": [".NET"]
     },
@@ -404,7 +404,7 @@
         "keyword_dict": {
             "Cpp": ["c++"]
         },
-        "explaination": "keyword with special character",
+        "explanation": "keyword with special character",
         "keywords": ["Cpp"],
         "keywords_case_sensitive": ["Cpp"]
     },
@@ -413,7 +413,7 @@
         "keyword_dict": {
             "Python": ["python."]
         },
-        "explaination": "Ending with special character",
+        "explanation": "Ending with special character",
         "keywords": ["Python"],
         "keywords_case_sensitive": ["Python"]
     },
@@ -422,7 +422,7 @@
         "keyword_dict": {
             "Python": ["python"]
         },
-        "explaination": "Ending with special character",
+        "explanation": "Ending with special character",
         "keywords": ["Python"],
         "keywords_case_sensitive": ["Python"]
     },
@@ -431,7 +431,7 @@
         "keyword_dict": {
             "Python": ["python prog"]
         },
-        "explaination": "Negative test case",
+        "explanation": "Negative test case",
         "keywords": [],
         "keywords_case_sensitive": []
     },
@@ -443,7 +443,7 @@
             "Institute": ["institute"],
             "Distributed Super Computing": ["distributed super computing"]
         },
-        "explaination": "Negative test case",
+        "explanation": "Negative test case",
         "keywords": ["Distributed Super Computing", "Institute", "Java"],
         "keywords_case_sensitive": ["Distributed Super Computing", "Institute", "Java"]
     },
@@ -454,7 +454,7 @@
             "XBP1s": ["XBP1s"],
             "UPR": ["upr"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["IRE1", "XBP1s", "UPR"],
         "keywords_case_sensitive": ["IRE1", "XBP1s"]
     },
@@ -464,7 +464,7 @@
             "spring framework": ["spring", "spring framework"],
             "framework": ["framework"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["spring framework"],
         "keywords_case_sensitive": ["spring framework"]
     }

--- a/test/keyword_extractor_test_cases.json
+++ b/test/keyword_extractor_test_cases.json
@@ -9,6 +9,15 @@
         "keywords_case_sensitive": ["Python"]
     },
     {
+        "sentence": "I like python",
+        "keyword_dict": {
+            "Pythonizer": ["pythonizer"]
+        },
+        "explanation": "Incomplete keyword at the end of the sentence.",
+        "keywords": [],
+        "keywords_case_sensitive": []
+    },
+    {
         "sentence": "python I like",
         "keyword_dict": {
             "Python": ["python"]

--- a/test/keyword_remover_test_cases.json
+++ b/test/keyword_remover_test_cases.json
@@ -101,5 +101,16 @@
         },
         "keywords": ["spring framework"],
         "keywords_case_sensitive": ["spring framework"]
+    },
+    {
+        "sentence": "computer vision",
+        "keyword_dict": {
+            "computer vision": ["computer vision"]
+        },
+        "remove_keyword_dict": {
+            "computer vision center": ["computer vision center"]
+        },
+        "keywords": ["computer vision"],
+        "keywords_case_sensitive": ["computer vision"]
     }
 ]

--- a/test/test_kp_exceptions.py
+++ b/test/test_kp_exceptions.py
@@ -1,0 +1,54 @@
+from collections import defaultdict
+from flashtext import KeywordProcessor
+import logging
+import unittest
+import pytest
+import json
+import re
+
+logger = logging.getLogger(__name__)
+
+
+class TestKPExceptions(unittest.TestCase):
+    def setUp(self):
+        logger.info("Starting...")
+
+    def tearDown(self):
+        logger.info("Ending.")
+
+    def test_iterator_NotImplementedError(self):
+        keyword_processor = KeywordProcessor()
+        keyword_processor.add_keyword('j2ee', 'Java')
+        keyword_processor.add_keyword('colour', 'color')
+        keyword_processor.get_all_keywords()
+        with pytest.raises(NotImplementedError):
+            for value in keyword_processor:
+                pass
+
+    def test_add_keyword_file_missing(self):
+        keyword_processor = KeywordProcessor()
+        with pytest.raises(IOError):
+            keyword_processor.add_keyword_from_file('missing_file')
+
+    def test_add_keyword_file_missing(self):
+        keyword_processor = KeywordProcessor()
+        keyword_dict = {
+            "java": "java_2e",
+            "product management": "product manager"
+        }
+        with pytest.raises(AttributeError):
+            keyword_processor.add_keywords_from_dict(keyword_dict)
+
+    def test_empty_string(self):
+        keyword_processor = KeywordProcessor()
+        keyword_dict = {
+            "java": "java_2e",
+            "product management": "product manager"
+        }
+        self.assertEqual(keyword_processor.extract_keywords(""), [],
+                         "new_sentence don't match the expected result")
+        self.assertEqual(keyword_processor.replace_keywords(""), "",
+                         "new_sentence don't match the expected result")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_kp_exceptions.py
+++ b/test/test_kp_exceptions.py
@@ -30,7 +30,13 @@ class TestKPExceptions(unittest.TestCase):
         with pytest.raises(IOError):
             keyword_processor.add_keyword_from_file('missing_file')
 
-    def test_add_keyword_file_missing(self):
+    def test_add_keyword_from_list(self):
+        keyword_processor = KeywordProcessor()
+        keyword_list = "java"
+        with pytest.raises(AttributeError):
+            keyword_processor.add_keywords_from_list(keyword_list)
+
+    def test_add_keyword_from_dictionary(self):
         keyword_processor = KeywordProcessor()
         keyword_dict = {
             "java": "java_2e",
@@ -38,6 +44,21 @@ class TestKPExceptions(unittest.TestCase):
         }
         with pytest.raises(AttributeError):
             keyword_processor.add_keywords_from_dict(keyword_dict)
+
+    def test_remove_keyword_from_list(self):
+        keyword_processor = KeywordProcessor()
+        keyword_list = "java"
+        with pytest.raises(AttributeError):
+            keyword_processor.remove_keywords_from_list(keyword_list)
+
+    def test_remove_keyword_from_dictionary(self):
+        keyword_processor = KeywordProcessor()
+        keyword_dict = {
+            "java": "java_2e",
+            "product management": "product manager"
+        }
+        with pytest.raises(AttributeError):
+            keyword_processor.remove_keywords_from_dict(keyword_dict)
 
     def test_empty_string(self):
         keyword_processor = KeywordProcessor()

--- a/test/test_kp_extract_span.py
+++ b/test/test_kp_extract_span.py
@@ -1,0 +1,53 @@
+from flashtext import KeywordProcessor
+import logging
+import unittest
+import json
+
+logger = logging.getLogger(__name__)
+
+
+class TestKPExtractorSpan(unittest.TestCase):
+    def setUp(self):
+        logger.info("Starting...")
+        with open('test/keyword_extractor_test_cases.json') as f:
+            self.test_cases = json.load(f)
+
+    def tearDown(self):
+        logger.info("Ending.")
+
+    def test_extract_keywords(self):
+        """For each of the test case initialize a new KeywordProcessor.
+        Add the keywords the test case to KeywordProcessor.
+        Extract keywords and check if they match the expected result for the test case.
+
+        """
+        for test_id, test_case in enumerate(self.test_cases):
+            keyword_processor = KeywordProcessor()
+            for key in test_case['keyword_dict']:
+                keyword_processor.add_keywords_from_list(test_case['keyword_dict'][key])
+            keywords_extracted = keyword_processor.extract_keywords(test_case['sentence'], span_info=True)
+            for kwd in keywords_extracted:
+                # returned keyword lowered should match the sapn from sentence
+                self.assertEqual(
+                    kwd[0].lower(), test_case['sentence'].lower()[kwd[1]:kwd[2]],
+                    "keywords span don't match the expected results for test case: {}".format(test_id))
+
+    def test_extract_keywords_case_sensitive(self):
+        """For each of the test case initialize a new KeywordProcessor.
+        Add the keywords the test case to KeywordProcessor.
+        Extract keywords and check if they match the expected result for the test case.
+
+        """
+        for test_id, test_case in enumerate(self.test_cases):
+            keyword_processor = KeywordProcessor(case_sensitive=True)
+            for key in test_case['keyword_dict']:
+                keyword_processor.add_keywords_from_list(test_case['keyword_dict'][key])
+            keywords_extracted = keyword_processor.extract_keywords(test_case['sentence'], span_info=True)
+            for kwd in keywords_extracted:
+                # returned keyword should match the sapn from sentence
+                self.assertEqual(
+                    kwd[0], test_case['sentence'][kwd[1]:kwd[2]],
+                    "keywords span don't match the expected results for test case: {}".format(test_id))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_kp_get_all_keywords.py
+++ b/test/test_kp_get_all_keywords.py
@@ -1,0 +1,29 @@
+from collections import defaultdict
+from flashtext import KeywordProcessor
+import logging
+import unittest
+import json
+import re
+
+logger = logging.getLogger(__name__)
+
+
+class TestKPKeywords(unittest.TestCase):
+    def setUp(self):
+        logger.info("Starting...")
+
+    def tearDown(self):
+        logger.info("Ending.")
+
+    def test_list_loading(self):
+        keyword_processor = KeywordProcessor()
+        keyword_processor.add_keyword('j2ee', 'Java')
+        keyword_processor.add_keyword('onGoing', 'rendom')
+        keyword_processor.get_all_keywords()
+        self.assertEqual(keyword_processor.get_all_keywords(),
+                         {'j2ee': 'Java', 'ongoing': 'rendom'},
+                         "get_all_keywords didn't match expected results.")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_kp_get_all_keywords.py
+++ b/test/test_kp_get_all_keywords.py
@@ -15,7 +15,7 @@ class TestKPGetAllKeywords(unittest.TestCase):
     def tearDown(self):
         logger.info("Ending.")
 
-    def test_list_loading(self):
+    def test_get_all_keywords(self):
         keyword_processor = KeywordProcessor()
         keyword_processor.add_keyword('j2ee', 'Java')
         keyword_processor.add_keyword('colour', 'color')

--- a/test/test_kp_len.py
+++ b/test/test_kp_len.py
@@ -30,13 +30,13 @@ class TestKPLen(unittest.TestCase):
             kp_len = len(keyword_processor)
             kp_len_expected = sum([len(values) for key, values in test_case['keyword_dict'].items()])
             self.assertEqual(kp_len, kp_len_expected,
-                             "keyword processor length doesn't matches".format(test_id))
+                             "keyword processor length doesn't match".format(test_id))
             keyword_processor.remove_keywords_from_dict(test_case['remove_keyword_dict'])
             # check length
             kp_len = len(keyword_processor)
             kp_len_decreased = sum([len(values) for key, values in test_case['remove_keyword_dict'].items()])
             self.assertEqual(kp_len, kp_len_expected - kp_len_decreased,
-                             "keyword processor length doesn't matche for Text ID {}".format(test_id))
+                             "keyword processor length doesn't match for Text ID {}".format(test_id))
 
     def test_remove_keywords_dictionary_len(self):
         """For each of the test case initialize a new KeywordProcessor.
@@ -61,6 +61,6 @@ class TestKPLen(unittest.TestCase):
             keyword_processor_two.add_keywords_from_dict(new_dictionary)
             kp_len_two = len(keyword_processor_two)
             self.assertEqual(kp_len, kp_len_two,
-                             "keyword processor length doesn't matche for Text ID {}".format(test_id))
+                             "keyword processor length doesn't match for Text ID {}".format(test_id))
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_kp_len.py
+++ b/test/test_kp_len.py
@@ -4,8 +4,12 @@ import logging
 import unittest
 import json
 import re
+import sys
 
 logger = logging.getLogger(__name__)
+logger.level = logging.DEBUG
+stream_handler = logging.StreamHandler(sys.stdout)
+logger.addHandler(stream_handler)
 
 
 class TestKPLen(unittest.TestCase):
@@ -16,27 +20,6 @@ class TestKPLen(unittest.TestCase):
 
     def tearDown(self):
         logger.info("Ending.")
-
-    def test_remove_keywords_len(self):
-        """For each of the test case initialize a new KeywordProcessor.
-        Add the keywords the test case to KeywordProcessor.
-        Remove the keywords in remove_keyword_dict
-        Extract keywords and check if they match the expected result for the test case.
-        """
-        for test_id, test_case in enumerate(self.test_cases):
-            keyword_processor = KeywordProcessor()
-            keyword_processor.add_keywords_from_dict(test_case['keyword_dict'])
-            # check length
-            kp_len = len(keyword_processor)
-            kp_len_expected = sum([len(values) for key, values in test_case['keyword_dict'].items()])
-            self.assertEqual(kp_len, kp_len_expected,
-                             "keyword processor length doesn't match".format(test_id))
-            keyword_processor.remove_keywords_from_dict(test_case['remove_keyword_dict'])
-            # check length
-            kp_len = len(keyword_processor)
-            kp_len_decreased = sum([len(values) for key, values in test_case['remove_keyword_dict'].items()])
-            self.assertEqual(kp_len, kp_len_expected - kp_len_decreased,
-                             "keyword processor length doesn't match for Text ID {}".format(test_id))
 
     def test_remove_keywords_dictionary_len(self):
         """For each of the test case initialize a new KeywordProcessor.

--- a/test/test_kp_term_in_kp.py
+++ b/test/test_kp_term_in_kp.py
@@ -29,6 +29,29 @@ class TestKPDictionaryLikeFeatures(unittest.TestCase):
         self.assertEqual(keyword_processor['Test'],
                          None,
                          "get_keyword didn't return expected Keyword")
+        self.assertTrue('colour' in keyword_processor,
+                        "get_keyword didn't return expected Keyword")
+        self.assertFalse('Test' in keyword_processor,
+                         "get_keyword didn't return expected Keyword")
+
+    def test_term_in_dictionary_case_sensitive(self):
+        keyword_processor = KeywordProcessor(case_sensitive=True)
+        keyword_processor.add_keyword('j2ee', 'Java')
+        keyword_processor.add_keyword('colour', 'color')
+        keyword_processor.get_keyword('j2ee')
+        self.assertEqual(keyword_processor.get_keyword('j2ee'),
+                         'Java',
+                         "get_keyword didn't return expected Keyword")
+        self.assertEqual(keyword_processor['colour'],
+                         'color',
+                         "get_keyword didn't return expected Keyword")
+        self.assertEqual(keyword_processor['J2ee'],
+                         None,
+                         "get_keyword didn't return expected Keyword")
+        self.assertTrue('colour' in keyword_processor,
+                        "get_keyword didn't return expected Keyword")
+        self.assertFalse('Colour' in keyword_processor,
+                         "get_keyword didn't return expected Keyword")
 
 
 if __name__ == '__main__':

--- a/test/test_kp_term_in_kp.py
+++ b/test/test_kp_term_in_kp.py
@@ -8,7 +8,7 @@ import re
 logger = logging.getLogger(__name__)
 
 
-class TestKPGetAllKeywords(unittest.TestCase):
+class TestKPTermInKP(unittest.TestCase):
     def setUp(self):
         logger.info("Starting...")
 
@@ -18,10 +18,10 @@ class TestKPGetAllKeywords(unittest.TestCase):
     def test_list_loading(self):
         keyword_processor = KeywordProcessor()
         keyword_processor.add_keyword('j2ee', 'Java')
-        keyword_processor.add_keyword('colour', 'color')
+        keyword_processor.add_keyword('onGoing', 'rendom')
         keyword_processor.get_all_keywords()
         self.assertEqual(keyword_processor.get_all_keywords(),
-                         {'colour': 'color', 'j2ee': 'Java'},
+                         {'j2ee': 'Java', 'ongoing': 'rendom'},
                          "get_all_keywords didn't match expected results.")
 
 

--- a/test/test_kp_term_in_kp.py
+++ b/test/test_kp_term_in_kp.py
@@ -8,21 +8,27 @@ import re
 logger = logging.getLogger(__name__)
 
 
-class TestKPTermInKP(unittest.TestCase):
+class TestKPDictionaryLikeFeatures(unittest.TestCase):
     def setUp(self):
         logger.info("Starting...")
 
     def tearDown(self):
         logger.info("Ending.")
 
-    def test_list_loading(self):
+    def test_term_in_dictionary(self):
         keyword_processor = KeywordProcessor()
         keyword_processor.add_keyword('j2ee', 'Java')
-        keyword_processor.add_keyword('onGoing', 'rendom')
-        keyword_processor.get_all_keywords()
-        self.assertEqual(keyword_processor.get_all_keywords(),
-                         {'j2ee': 'Java', 'ongoing': 'rendom'},
-                         "get_all_keywords didn't match expected results.")
+        keyword_processor.add_keyword('colour', 'color')
+        keyword_processor.get_keyword('j2ee')
+        self.assertEqual(keyword_processor.get_keyword('j2ee'),
+                         'Java',
+                         "get_keyword didn't return expected Keyword")
+        self.assertEqual(keyword_processor['colour'],
+                         'color',
+                         "get_keyword didn't return expected Keyword")
+        self.assertEqual(keyword_processor['Test'],
+                         None,
+                         "get_keyword didn't return expected Keyword")
 
 
 if __name__ == '__main__':

--- a/test/test_remove_keywords.py
+++ b/test/test_remove_keywords.py
@@ -31,6 +31,21 @@ class TestKeywordRemover(unittest.TestCase):
             self.assertEqual(keywords_extracted, test_case['keywords'],
                              "keywords_extracted don't match the expected results for test case: {}".format(test_id))
 
+    def test_remove_keywords_using_list(self):
+        """For each of the test case initialize a new KeywordProcessor.
+        Add the keywords the test case to KeywordProcessor.
+        Remove the keywords in remove_keyword_dict
+        Extract keywords and check if they match the expected result for the test case.
+        """
+        for test_id, test_case in enumerate(self.test_cases):
+            keyword_processor = KeywordProcessor()
+            keyword_processor.add_keywords_from_dict(test_case['keyword_dict'])
+            for key in test_case['remove_keyword_dict']:
+                keyword_processor.remove_keywords_from_list(test_case['remove_keyword_dict'][key])
+            keywords_extracted = keyword_processor.extract_keywords(test_case['sentence'])
+            self.assertEqual(keywords_extracted, test_case['keywords'],
+                             "keywords_extracted don't match the expected results for test case: {}".format(test_id))
+
     def test_remove_keywords_dictionary_compare(self):
         """For each of the test case initialize a new KeywordProcessor.
         Add the keywords the test case to KeywordProcessor.


### PR DESCRIPTION
Hi there,

I think the only safe way to deal with issue #48 would be to test against the `\W` class [1]. Judging from the benchmarks linked on https://github.com/vi3k6i5/flashtext#why-not-regex this seems to run slower by a factor of 1-2 though.

Best,
Alex

[1] Quoting the [Python docs](https://docs.python.org/3/library/re.html):

> \b is defined as the boundary between a \w and a \W character (or vice versa), or between \w and the beginning/end of the string. This means that r'\bfoo\b' matches 'foo', 'foo.', '(foo)', 'bar foo baz' but not 'foobar' or 'foo3'.