### PR TITLE
some keyword has multiple different clean_names

### DIFF
--- a/flashtext/keyword.py
+++ b/flashtext/keyword.py
@@ -149,7 +149,8 @@ class KeywordProcessor(object):
             if self._keyword not in current_dict:
                 status = True
                 self._terms_in_trie += 1
-            current_dict[self._keyword] = clean_name
+                current_dict[self._keyword] = set()
+            current_dict[self._keyword].add(clean_name)
         return status
 
     def __delitem__(self, keyword):


### PR DESCRIPTION
set the _keyword=set() for some keyword has multiple different clean_names
For example:
    keyword_processor = KeywordProcessor()
    keyword_dict = {"news_channel": ["CNN","CCTV","BBC"],"neural_network": ["CNN", "RNN"]}
    keyword_processor.add_keywords_from_dict(keyword_dict)
    keyword_processor.extract_keywords('I like CNN')
we hope get result as follows:
   ("news_channel", "neural_network")