### PR TITLE
Return sentences that contain keywords

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,4 @@
 [run]
-omit = test/*
+omit = 
+    test/*
+    setup.py

--- a/README.rst
+++ b/README.rst
@@ -69,12 +69,12 @@ Case Sensitive example
 
 Span of keywords extracted
     >>> from flashtext import KeywordProcessor
-    >>> keyword_processor = KeywordProcessor(case_sensitive=True)
+    >>> keyword_processor = KeywordProcessor()
     >>> keyword_processor.add_keyword('Big Apple', 'New York')
     >>> keyword_processor.add_keyword('Bay Area')
     >>> keywords_found = keyword_processor.extract_keywords('I love big Apple and Bay Area.', span_info=True)
     >>> keywords_found
-    >>> # [('Bay Area', 21, 29)]
+    >>> # [('New York', 7, 16), ('Bay Area', 21, 29)]
 
 No clean name for Keywords
     >>> from flashtext import KeywordProcessor

--- a/README.rst
+++ b/README.rst
@@ -134,9 +134,9 @@ Get all keywords in dictionary
     >>> from flashtext import KeywordProcessor
     >>> keyword_processor = KeywordProcessor()
     >>> keyword_processor.add_keyword('j2ee', 'Java')
-    >>> keyword_processor.add_keyword('onGoing', 'rendom')
+    >>> keyword_processor.add_keyword('colour', 'color')
     >>> keyword_processor.get_all_keywords()
-    >>> # output: {'j2ee': 'Java', 'ongoing': 'rendom'}
+    >>> # output: {'colour': 'color', 'j2ee': 'Java'}
 
 For detecting Word Boundary currently any character other than this `\\w` `[A-Za-z0-9_]` is considered a word boundary.
 

--- a/README.rst
+++ b/README.rst
@@ -199,8 +199,27 @@ The idea for this library came from the following `StackOverflow question
 <https://stackoverflow.com/questions/44178449/regex-replace-is-taking-time-for-millions-of-documents-how-to-make-it-faster>`_.
 
 
-References
+Citation
 ----------
+
+The original paper published on `FlashText algorithm <https://arxiv.org/abs/1711.00046>`_.
+
+::
+
+    @ARTICLE{2017arXiv171100046S,
+       author = {{Singh}, V.},
+        title = "{Replace or Retrieve Keywords In Documents at Scale}",
+      journal = {ArXiv e-prints},
+    archivePrefix = "arXiv",
+       eprint = {1711.00046},
+     primaryClass = "cs.DS",
+     keywords = {Computer Science - Data Structures and Algorithms},
+         year = 2017,
+        month = oct,
+       adsurl = {http://adsabs.harvard.edu/abs/2017arXiv171100046S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+    }
+
 
 The original paper published on `FlashText algorithm <https://arxiv.org/abs/1711.00046>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,15 @@ Case Sensitive example
     >>> keywords_found
     >>> # ['Bay Area']
 
+Span of keywords extracted
+    >>> from flashtext import KeywordProcessor
+    >>> keyword_processor = KeywordProcessor(case_sensitive=True)
+    >>> keyword_processor.add_keyword('Big Apple', 'New York')
+    >>> keyword_processor.add_keyword('Bay Area')
+    >>> keywords_found = keyword_processor.extract_keywords('I love big Apple and Bay Area.', span_info=True)
+    >>> keywords_found
+    >>> # [('Bay Area', 21, 29)]
+
 No clean name for Keywords
     >>> from flashtext import KeywordProcessor
     >>> keyword_processor = KeywordProcessor()

--- a/README.rst
+++ b/README.rst
@@ -220,9 +220,6 @@ The original paper published on `FlashText algorithm <https://arxiv.org/abs/1711
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
     }
 
-
-The original paper published on `FlashText algorithm <https://arxiv.org/abs/1711.00046>`_.
-
 The article published on `Medium freeCodeCamp <https://medium.freecodecamp.org/regex-was-taking-5-days-flashtext-does-it-in-15-minutes-55f04411025f>`_.
 
 

--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,15 @@ Span of keywords extracted
     >>> keywords_found
     >>> # [('New York', 7, 16), ('Bay Area', 21, 29)]
 
+Get Extra information with keywords extracted
+    >>> from flashtext import KeywordProcessor
+    >>> kp = KeywordProcessor()
+    >>> kp.add_keyword('Taj Mahal', ('Monument', 'Taj Mahal'))
+    >>> kp.add_keyword('Delhi', ('Location', 'Delhi'))
+    >>> kp.extract_keywords('Taj Mahal is in Delhi.')
+    >>> # [('Monument', 'Taj Mahal'), ('Location', 'Delhi')]
+    >>> # NOTE: replace_keywords feature won't work with this.
+
 No clean name for Keywords
     >>> from flashtext import KeywordProcessor
     >>> keyword_processor = KeywordProcessor()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,12 +66,12 @@ Case Sensitive example
 
 Span of keywords extracted
     >>> from flashtext import KeywordProcessor
-    >>> keyword_processor = KeywordProcessor(case_sensitive=True)
+    >>> keyword_processor = KeywordProcessor()
     >>> keyword_processor.add_keyword('Big Apple', 'New York')
     >>> keyword_processor.add_keyword('Bay Area')
     >>> keywords_found = keyword_processor.extract_keywords('I love big Apple and Bay Area.', span_info=True)
     >>> keywords_found
-    >>> # [('Bay Area', 21, 29)]
+    >>> # [('New York', 7, 16), ('Bay Area', 21, 29)]
 
 No clean name for Keywords
     >>> from flashtext import KeywordProcessor

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -228,9 +228,6 @@ The original paper published on `FlashText algorithm <https://arxiv.org/abs/1711
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
     }
 
-
-The original paper published on `FlashText algorithm <https://arxiv.org/abs/1711.00046>`_.
-
 The article published on `Medium freeCodeCamp <https://medium.freecodecamp.org/regex-was-taking-5-days-flashtext-does-it-in-15-minutes-55f04411025f>`_.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -131,9 +131,9 @@ Get all keywords in dictionary
     >>> from flashtext import KeywordProcessor
     >>> keyword_processor = KeywordProcessor()
     >>> keyword_processor.add_keyword('j2ee', 'Java')
-    >>> keyword_processor.add_keyword('onGoing', 'rendom')
+    >>> keyword_processor.add_keyword('colour', 'color')
     >>> keyword_processor.get_all_keywords()
-    >>> # output: {'j2ee': 'Java', 'ongoing': 'rendom'}
+    >>> # output: {'colour': 'color', 'j2ee': 'Java'}
 
 For detecting Word Boundary currently any character other than this `\\w` `[A-Za-z0-9_]` is considered a word boundary.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,6 +73,15 @@ Span of keywords extracted
     >>> keywords_found
     >>> # [('New York', 7, 16), ('Bay Area', 21, 29)]
 
+Get Extra information with keywords extracted
+    >>> from flashtext import KeywordProcessor
+    >>> kp = KeywordProcessor()
+    >>> kp.add_keyword('Taj Mahal', ('Monument', 'Taj Mahal'))
+    >>> kp.add_keyword('Delhi', ('Location', 'Delhi'))
+    >>> kp.extract_keywords('Taj Mahal is in Delhi.')
+    >>> # [('Monument', 'Taj Mahal'), ('Location', 'Delhi')]
+    >>> # NOTE: replace_keywords feature won't work with this.
+
 No clean name for Keywords
     >>> from flashtext import KeywordProcessor
     >>> keyword_processor = KeywordProcessor()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -207,8 +207,27 @@ The idea for this library came from the following `StackOverflow question
 <https://stackoverflow.com/questions/44178449/regex-replace-is-taking-time-for-millions-of-documents-how-to-make-it-faster>`_.
 
 
-References
+Citation
 ----------
+
+The original paper published on `FlashText algorithm <https://arxiv.org/abs/1711.00046>`_.
+
+::
+
+    @ARTICLE{2017arXiv171100046S,
+       author = {{Singh}, V.},
+        title = "{Replace or Retrieve Keywords In Documents at Scale}",
+      journal = {ArXiv e-prints},
+    archivePrefix = "arXiv",
+       eprint = {1711.00046},
+     primaryClass = "cs.DS",
+     keywords = {Computer Science - Data Structures and Algorithms},
+         year = 2017,
+        month = oct,
+       adsurl = {http://adsabs.harvard.edu/abs/2017arXiv171100046S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+    }
+
 
 The original paper published on `FlashText algorithm <https://arxiv.org/abs/1711.00046>`_.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,6 +64,15 @@ Case Sensitive example
     >>> keywords_found
     >>> # ['Bay Area']
 
+Span of keywords extracted
+    >>> from flashtext import KeywordProcessor
+    >>> keyword_processor = KeywordProcessor(case_sensitive=True)
+    >>> keyword_processor.add_keyword('Big Apple', 'New York')
+    >>> keyword_processor.add_keyword('Bay Area')
+    >>> keywords_found = keyword_processor.extract_keywords('I love big Apple and Bay Area.', span_info=True)
+    >>> keywords_found
+    >>> # [('Bay Area', 21, 29)]
+
 No clean name for Keywords
     >>> from flashtext import KeywordProcessor
     >>> keyword_processor = KeywordProcessor()

--- a/flashtext/keyword.py
+++ b/flashtext/keyword.py
@@ -289,6 +289,7 @@ class KeywordProcessor(object):
 
         Args:
             keyword_file : path to keywords file
+            encoding : specify the encoding of the file
 
         Examples:
             keywords file format can be like:

--- a/flashtext/keyword.py
+++ b/flashtext/keyword.py
@@ -9,11 +9,14 @@ class KeywordProcessor(object):
     Attributes:
         _keyword (str): Used as key to store keywords in trie dictionary.
             Defaults to '_keyword_'
-        non_word_boundaries (set(str)): Characters that will determine if the word is continuing.
+        non_word_boundaries (set(str)):
+            Characters that will determine if the word is continuing.
             Defaults to set([A-Za-z0-9_])
-        keyword_trie_dict (dict): Trie dict built character by character, that is used for lookup
+        keyword_trie_dict (dict):
+            Trie dict built character by character, that is used for lookup
             Defaults to empty dictionary
-        case_sensitive (boolean): if the search algorithm should be case sensitive or not.
+        case_sensitive (boolean):
+            if the search algorithm should be case sensitive or not.
             Defaults to False
 
     Examples:
@@ -26,29 +29,36 @@ class KeywordProcessor(object):
         >>> clean_names = ['new york', 'new york', 'san francisco']
         >>> for keyword_name, clean_name in zip(keyword_names, clean_names):
         >>>     keyword_processor.add_keyword(keyword_name, clean_name)
-        >>> keywords_found = keyword_processor.extract_keywords('I love SF and NY. new-york is the best.')
+        >>> keywords_found = keyword_processor.extract_keywords('I \
+                            love SF and NY. new-york is the best.')
         >>> keywords_found
         >>> ['san francisco', 'new york', 'new york']
 
     Note:
-        * loosely based on `Aho-Corasick algorithm <https://en.wikipedia.org/wiki/Aho%E2%80%93Corasick_algorithm>`_.
-        * Idea came from this `Stack Overflow Question <https://stackoverflow.com/questions/44178449/regex-replace-is-taking-time-for-millions-of-documents-how-to-make-it-faster>`_.
+        * loosely based on `Aho-Corasick algorithm
+        <https://en.wikipedia.org/wiki/Aho%E2%80%93Corasick_algorithm>`_.
+        * Idea came from this `Stack Overflow Question
+        <https://stackoverflow.com/questions/44178449/regex-replace-is-\
+        taking-time-for-millions-of-documents-how-to-make-it-faster>`_.
     """
 
     def __init__(self, case_sensitive=False):
         """
         Args:
-            case_sensitive (boolean): Keyword search should be case sensitive set or not.
+            case_sensitive (boolean):
+                Keyword search should be case sensitive set or not.
                 Defaults to False
         """
         self._keyword = '_keyword_'
         self._white_space_chars = set(['.', '\t', '\n', '\a', ' ', ','])
         try:
             # python 2.x
-            self.non_word_boundaries = set(string.digits + string.letters + '_')
+            self.non_word_boundaries = set(string.digits +
+                                           string.letters + '_')
         except AttributeError:
             # python 3.x
-            self.non_word_boundaries = set(string.digits + string.ascii_letters + '_')
+            self.non_word_boundaries = set(string.digits +
+                                           string.ascii_letters + '_')
         self.keyword_trie_dict = dict()
         self.case_sensitive = case_sensitive
         self._terms_in_trie = 0
@@ -72,7 +82,8 @@ class KeywordProcessor(object):
 
         Returns:
             status : bool
-                If word is present as it is in keyword_trie_dict then we return True, else False
+                If word is present as it is in keyword_trie_dict
+                then we return True, else False
 
         Examples:
             >>> keyword_processor.add_keyword('Big Apple')
@@ -82,15 +93,15 @@ class KeywordProcessor(object):
         """
         if not self.case_sensitive:
             word = word.lower()
-        current_dict = self.keyword_trie_dict
+        curr_dict = self.keyword_trie_dict
         len_covered = 0
         for char in word:
-            if char in current_dict:
-                current_dict = current_dict[char]
+            if char in curr_dict:
+                curr_dict = curr_dict[char]
                 len_covered += 1
             else:
                 break
-        return self._keyword in current_dict and len_covered == len(word)
+        return self._keyword in curr_dict and len_covered == len(word)
 
     def __getitem__(self, word):
         """if word is present in keyword_trie_dict return the clean name for it.
@@ -101,7 +112,8 @@ class KeywordProcessor(object):
 
         Returns:
             keyword : string
-                If word is present as it is in keyword_trie_dict then we return keyword mapped to it.
+                If word is present as it is in keyword_trie_dict
+                then we return keyword mapped to it.
 
         Examples:
             >>> keyword_processor.add_keyword('Big Apple', 'New York')
@@ -110,16 +122,16 @@ class KeywordProcessor(object):
         """
         if not self.case_sensitive:
             word = word.lower()
-        current_dict = self.keyword_trie_dict
+        curr_dict = self.keyword_trie_dict
         len_covered = 0
         for char in word:
-            if char in current_dict:
-                current_dict = current_dict[char]
+            if char in curr_dict:
+                curr_dict = curr_dict[char]
                 len_covered += 1
             else:
                 break
-        if self._keyword in current_dict and len_covered == len(word):
-            return current_dict[self._keyword]
+        if self._keyword in curr_dict and len_covered == len(word):
+            return curr_dict[self._keyword]
 
     def __setitem__(self, keyword, clean_name=None):
         """To add keyword to the dictionary
@@ -130,7 +142,8 @@ class KeywordProcessor(object):
                 keyword that you want to identify
 
             clean_name : string
-                clean term for that keyword that you would want to get back in return or replace
+                clean term for that keyword that you would want
+                to get back in return or replace
                 if not provided, keyword will be used as the clean name also.
 
         Examples:
@@ -143,13 +156,13 @@ class KeywordProcessor(object):
         if keyword and clean_name:
             if not self.case_sensitive:
                 keyword = keyword.lower()
-            current_dict = self.keyword_trie_dict
+            curr_dict = self.keyword_trie_dict
             for letter in keyword:
-                current_dict = current_dict.setdefault(letter, {})
-            if self._keyword not in current_dict:
+                curr_dict = curr_dict.setdefault(letter, {})
+            if self._keyword not in curr_dict:
                 status = True
                 self._terms_in_trie += 1
-            current_dict[self._keyword] = clean_name
+            curr_dict[self._keyword] = clean_name
         return status
 
     def __delitem__(self, keyword):
@@ -168,20 +181,21 @@ class KeywordProcessor(object):
         if keyword:
             if not self.case_sensitive:
                 keyword = keyword.lower()
-            current_dict = self.keyword_trie_dict
+            curr_dict = self.keyword_trie_dict
             character_trie_list = []
             for letter in keyword:
-                if letter in current_dict:
-                    character_trie_list.append((letter, current_dict))
-                    current_dict = current_dict[letter]
+                if letter in curr_dict:
+                    character_trie_list.append((letter, curr_dict))
+                    curr_dict = curr_dict[letter]
                 else:
                     # if character is not found, break out of the loop
-                    current_dict = None
+                    curr_dict = None
                     break
-            # remove the characters from trie dict if there are no other keywords with them
-            if current_dict and self._keyword in current_dict:
+            # remove the characters from trie dict if there
+            # are no other keywords with them
+            if curr_dict and self._keyword in curr_dict:
                 # we found a complete match for input keyword.
-                character_trie_list.append((self._keyword, current_dict))
+                character_trie_list.append((self._keyword, curr_dict))
                 character_trie_list.reverse()
 
                 for key_to_remove, dict_pointer in character_trie_list:
@@ -231,7 +245,8 @@ class KeywordProcessor(object):
                 keyword that you want to identify
 
             clean_name : string
-                clean term for that keyword that you would want to get back in return or replace
+                clean term for that keyword that you would want
+                to get back in return or replace
                 if not provided, keyword will be used as the clean name also.
 
         Returns:
@@ -279,7 +294,8 @@ class KeywordProcessor(object):
 
         Returns:
             keyword : string
-                If word is present as it is in keyword_trie_dict then we return keyword mapped to it.
+                If word is present as it is in keyword_trie_dict
+                then we return keyword mapped to it.
 
         Examples:
             >>> keyword_processor.add_keyword('Big Apple', 'New York')
@@ -330,7 +346,8 @@ class KeywordProcessor(object):
         """To add keywords from a dictionary
 
         Args:
-            keyword_dict (dict): A dictionary with `str` key and (list `str`) as value
+            keyword_dict (dict):
+            A dictionary with `str` key and(list `str`) as value
 
         Examples:
             >>> keyword_dict = {
@@ -345,7 +362,8 @@ class KeywordProcessor(object):
         """
         for clean_name, keywords in keyword_dict.items():
             if not isinstance(keywords, list):
-                raise AttributeError("Value of key {} should be a list".format(clean_name))
+                raise AttributeError("Value of key {}\
+                    should be a list".format(clean_name))
 
             for keyword in keywords:
                 self.add_keyword(keyword, clean_name)
@@ -354,7 +372,8 @@ class KeywordProcessor(object):
         """To remove keywords from a dictionary
 
         Args:
-            keyword_dict (dict): A dictionary with `str` key and (list `str`) as value
+            keyword_dict (dict):
+            A dictionary with `str` key and(list `str`) as value
 
         Examples:
             >>> keyword_dict = {
@@ -369,7 +388,8 @@ class KeywordProcessor(object):
         """
         for clean_name, keywords in keyword_dict.items():
             if not isinstance(keywords, list):
-                raise AttributeError("Value of key {} should be a list".format(clean_name))
+                raise AttributeError("Value of key {} should\
+                    be a list".format(clean_name))
 
             for keyword in keywords:
                 self.remove_keyword(keyword)
@@ -399,7 +419,7 @@ class KeywordProcessor(object):
             keyword_list (list(str)): List of keywords to remove
 
         Examples:
-            >>> keyword_processor.remove_keywords_from_list(["java", "python"]})
+        >>> keyword_processor.remove_keywords_from_list(["java", "python"]})
         Raises:
             AttributeError: If `keyword_list` is not a list.
 
@@ -410,19 +430,20 @@ class KeywordProcessor(object):
         for keyword in keyword_list:
             self.remove_keyword(keyword)
 
-    def get_all_keywords(self, term_so_far='', current_dict=None):
+    def get_all_keywords(self, term_so_far='', curr_dict=None):
         """Recursively builds a dictionary of keywords present in the dictionary
         And the clean name mapped to those keywords.
 
         Args:
             term_so_far : string
                 term built so far by adding all previous characters
-            current_dict : dict
+            curr_dict : dict
                 current recursive position in dictionary
 
         Returns:
             terms_present : dict
-                A map of key and value where each key is a term in the keyword_trie_dict.
+                A map of key and value where each key is a term
+                in the keyword_trie_dict.
                 And value mapped to it is the clean name mapped to it.
 
         Examples:
@@ -436,18 +457,19 @@ class KeywordProcessor(object):
         terms_present = {}
         if not term_so_far:
             term_so_far = ''
-        if current_dict is None:
-            current_dict = self.keyword_trie_dict
-        for key in current_dict:
+        if curr_dict is None:
+            curr_dict = self.keyword_trie_dict
+        for key in curr_dict:
             if key == '_keyword_':
-                terms_present[term_so_far] = current_dict[key]
+                terms_present[term_so_far] = curr_dict[key]
             else:
-                sub_values = self.get_all_keywords(term_so_far + key, current_dict[key])
+                sub_values = self.get_all_keywords(term_so_far +
+                                                   key, curr_dict[key])
                 for key in sub_values:
                     terms_present[key] = sub_values[key]
         return terms_present
 
-    def extract_keywords(self, sentence, span_info=False, fetch_sentences=False):
+    def extract_keywords(self, sentence, span_info=False, fetch_sent=False):
         """Searches in the string for all keywords present in corpus.
         Keywords present are added to a list `keywords_extracted` and returned.
 
@@ -455,14 +477,16 @@ class KeywordProcessor(object):
             sentence (str): Line of text where we will search for keywords
 
         Returns:
-            keywords_extracted (list(str)): List of terms/keywords found in sentence that match our corpus
+            keywords_extracted (list(str)):
+            List of terms/keywords found in sentence that match our corpus
 
         Examples:
             >>> from flashtext import KeywordProcessor
             >>> keyword_processor = KeywordProcessor()
             >>> keyword_processor.add_keyword('Big Apple', 'New York')
             >>> keyword_processor.add_keyword('Bay Area')
-            >>> keywords_found = keyword_processor.extract_keywords('I love Big Apple and Bay Area.')
+            >>> keywords_found = keyword_processor.extract_keywords('I\
+                                 love Big Apple and Bay Area.')
             >>> keywords_found
             >>> ['New York', 'Bay Area']
 
@@ -475,76 +499,81 @@ class KeywordProcessor(object):
             sentence = sentence.lower()
         idx = 0
         sentences_with_keyword = []
-        sequence_start_pos = 0
-        sequence_end_pos = 0
-        reset_current_dict = False
+        seq_start_pos = 0
+        seq_end_pos = 0
+        reset_curr_dict = False
 
         def _helper(sentence, idx):
             # print(idx)
             sentence_len = len(sentence)
-            current_dict = self.keyword_trie_dict
+            curr_dict = self.keyword_trie_dict
             while idx < sentence_len:
                 char = sentence[idx]
                 # print(char)
                 # when we reach a character that might denote word end
                 if char not in self.non_word_boundaries:
 
-                    # if end is present in current_dict
-                    if self._keyword in current_dict or char in current_dict:
+                    # if end is present in curr_dict
+                    if self._keyword in curr_dict or char in curr_dict:
                         # update longest sequence found
-                        sequence_found = None
-                        longest_sequence_found = None
+                        seq_found = None
+                        longest_seq_found = None
                         is_longer_seq_found = False
-                        if self._keyword in current_dict:
-                            sequence_found = current_dict[self._keyword]
-                            longest_sequence_found = current_dict[self._keyword]
-                            sequence_end_pos = idx
+                        if self._keyword in curr_dict:
+                            seq_found = curr_dict[self._keyword]
+                            longest_seq_found = curr_dict[self._keyword]
+                            seq_end_pos = idx
 
                         # re look for longest_sequence from this position
-                        if char in current_dict:
-                            current_dict_continued = current_dict[char]
+                        if char in curr_dict:
+                            curr_dict_continued = curr_dict[char]
 
                             idy = idx + 1
                             while idy < sentence_len:
                                 inner_char = sentence[idy]
-                                if inner_char not in self.non_word_boundaries and self._keyword in current_dict_continued:
+                                if inner_char not in self.non_word_boundaries\
+                                   and self._keyword in curr_dict_continued:
                                     # update longest sequence found
-                                    longest_sequence_found = current_dict_continued[self._keyword]
-                                    sequence_end_pos = idy
+                                    longest_seq_found = curr_dict_continued[
+                                                        self._keyword]
+                                    seq_end_pos = idy
                                     is_longer_seq_found = True
                                     print("sentence longer")
-                                if inner_char in current_dict_continued:
-                                    current_dict_continued = current_dict_continued[inner_char]
+                                if inner_char in curr_dict_continued:
+                                    curr_dict_continued = curr_dict_continued[
+                                                          inner_char]
                                 else:
                                     break
                                 idy += 1
                             else:
                                 # end of sentence reached.
-                                if self._keyword in current_dict_continued:
+                                if self._keyword in curr_dict_continued:
                                     # update longest sequence found
-                                    longest_sequence_found = current_dict_continued[self._keyword]
-                                    sequence_end_pos = idy
+                                    longest_seq_found = curr_dict_continued[
+                                                        self._keyword]
+                                    seq_end_pos = idy
                                     is_longer_seq_found = True
                             if is_longer_seq_found:
-                                idx = sequence_end_pos
-                        current_dict = self.keyword_trie_dict
-                        if longest_sequence_found:
-                            keywords_extracted.append((longest_sequence_found, sequence_start_pos, idx))
-                            if fetch_sentences:
-                                # print("longest_sequence_found: ", sentence)
+                                idx = seq_end_pos
+                        curr_dict = self.keyword_trie_dict
+                        if longest_seq_found:
+                            keywords_extracted.append((longest_seq_found,
+                                                       seq_start_pos, idx))
+                            if fetch_sent:
+                                # print("longest_seq_found: ", sentence)
                                 sentences_with_keyword.append(sentence)
-                        reset_current_dict = True
+                        reset_curr_dict = True
                     else:
-                        # we reset current_dict
-                        current_dict = self.keyword_trie_dict
-                        reset_current_dict = True
-                elif char in current_dict:
+                        # we reset curr_dict
+                        curr_dict = self.keyword_trie_dict
+                        reset_curr_dict = True
+                elif char in curr_dict:
                     # we can continue from this char
-                    current_dict = current_dict[char]
+                    curr_dict = curr_dict[char]
                 else:
-                    # we reset current_dict
-                    current_dict = self.keyword_trie_dict
-                    reset_current_dict = True
+                    # we reset curr_dict
+                    curr_dict = self.keyword_trie_dict
+                    reset_curr_dict = True
                     # skip to end of word
                     idy = idx + 1
                     while idy < sentence_len:
@@ -555,14 +584,15 @@ class KeywordProcessor(object):
                     idx = idy
                 # if we are end of sentence and have a sequence discovered
                 if idx + 1 >= sentence_len:
-                    if self._keyword in current_dict:
-                        sequence_found = current_dict[self._keyword]
-                        keywords_extracted.append((sequence_found, sequence_start_pos, sentence_len))
+                    if self._keyword in curr_dict:
+                        seq_found = curr_dict[self._keyword]
+                        keywords_extracted.append((seq_found, seq_start_pos,
+                                                   sentence_len))
                 idx += 1
-                if reset_current_dict:
-                    reset_current_dict = False
-                    sequence_start_pos = idx
-        if fetch_sentences:
+                if reset_curr_dict:
+                    reset_curr_dict = False
+                    seq_start_pos = idx
+        if fetch_sent:
             sentences = nltk.sent_tokenize(sentence)  # sentence is paragraph
             for each_sentence in sentences:
                 idx = 0
@@ -576,7 +606,8 @@ class KeywordProcessor(object):
 
     def replace_keywords(self, sentence):
         """Searches in the string for all keywords present in corpus.
-        Keywords present are replaced by the clean name and a new string is returned.
+        Keywords present are replaced by the clean name and
+        a new string is returned.
 
         Args:
             sentence (str): Line of text where we will replace keywords
@@ -589,7 +620,8 @@ class KeywordProcessor(object):
             >>> keyword_processor = KeywordProcessor()
             >>> keyword_processor.add_keyword('Big Apple', 'New York')
             >>> keyword_processor.add_keyword('Bay Area')
-            >>> new_sentence = keyword_processor.replace_keywords('I love Big Apple and bay area.')
+            >>> new_sentence = keyword_processor.replace_keywords('I
+                                love Big Apple and bay area.')
             >>> new_sentence
             >>> 'I love New York and Bay Area.'
 
@@ -601,98 +633,103 @@ class KeywordProcessor(object):
         orig_sentence = sentence
         if not self.case_sensitive:
             sentence = sentence.lower()
-        current_word = ''
-        current_dict = self.keyword_trie_dict
+        curr_word = ''
+        curr_dict = self.keyword_trie_dict
         current_white_space = ''
-        sequence_end_pos = 0
+        seq_end_pos = 0
         idx = 0
         sentence_len = len(sentence)
         while idx < sentence_len:
             char = sentence[idx]
-            current_word += orig_sentence[idx]
+            curr_word += orig_sentence[idx]
             # when we reach whitespace
             if char not in self.non_word_boundaries:
                 current_white_space = char
-                # if end is present in current_dict
-                if self._keyword in current_dict or char in current_dict:
+                # if end is present in curr_dict
+                if self._keyword in curr_dict or char in curr_dict:
                     # update longest sequence found
-                    sequence_found = None
-                    longest_sequence_found = None
+                    seq_found = None
+                    longest_seq_found = None
                     is_longer_seq_found = False
-                    if self._keyword in current_dict:
-                        sequence_found = current_dict[self._keyword]
-                        longest_sequence_found = current_dict[self._keyword]
-                        sequence_end_pos = idx
+                    if self._keyword in curr_dict:
+                        seq_found = curr_dict[self._keyword]
+                        longest_seq_found = curr_dict[self._keyword]
+                        seq_end_pos = idx
 
                     # re look for longest_sequence from this position
-                    if char in current_dict:
-                        current_dict_continued = current_dict[char]
-                        current_word_continued = current_word
+                    if char in curr_dict:
+                        curr_dict_continued = curr_dict[char]
+                        curr_word_continued = curr_word
                         idy = idx + 1
                         while idy < sentence_len:
                             inner_char = sentence[idy]
-                            current_word_continued += orig_sentence[idy]
-                            if inner_char not in self.non_word_boundaries and self._keyword in current_dict_continued:
+                            curr_word_continued += orig_sentence[idy]
+                            if inner_char not in self.non_word_boundaries and
+                            self._keyword in curr_dict_continued:
                                 # update longest sequence found
                                 current_white_space = inner_char
-                                longest_sequence_found = current_dict_continued[self._keyword]
-                                sequence_end_pos = idy
+                                longest_seq_found = curr_dict_continued[
+                                                    self._keyword]
+                                seq_end_pos = idy
                                 is_longer_seq_found = True
-                            if inner_char in current_dict_continued:
-                                current_dict_continued = current_dict_continued[inner_char]
+                            if inner_char in curr_dict_continued:
+                                curr_dict_continued = curr_dict_continued[
+                                                      inner_char]
                             else:
                                 break
                             idy += 1
                         else:
                             # end of sentence reached.
-                            if self._keyword in current_dict_continued:
+                            if self._keyword in curr_dict_continued:
                                 # update longest sequence found
                                 current_white_space = ''
-                                longest_sequence_found = current_dict_continued[self._keyword]
-                                sequence_end_pos = idy
+                                longest_seq_found = curr_dict_continued[
+                                                    self._keyword]
+                                seq_end_pos = idy
                                 is_longer_seq_found = True
                         if is_longer_seq_found:
-                            idx = sequence_end_pos
-                            current_word = current_word_continued
-                    current_dict = self.keyword_trie_dict
-                    if longest_sequence_found:
-                        new_sentence.append(longest_sequence_found + current_white_space)
-                        current_word = ''
+                            idx = seq_end_pos
+                            curr_word = curr_word_continued
+                    curr_dict = self.keyword_trie_dict
+                    if longest_seq_found:
+                        new_sentence.append(longest_seq_found +
+                                            current_white_space)
+                        curr_word = ''
                         current_white_space = ''
                     else:
-                        new_sentence.append(current_word)
-                        current_word = ''
+                        new_sentence.append(curr_word)
+                        curr_word = ''
                         current_white_space = ''
                 else:
-                    # we reset current_dict
-                    current_dict = self.keyword_trie_dict
-                    new_sentence.append(current_word)
-                    current_word = ''
+                    # we reset curr_dict
+                    curr_dict = self.keyword_trie_dict
+                    new_sentence.append(curr_word)
+                    curr_word = ''
                     current_white_space = ''
-            elif char in current_dict:
+            elif char in curr_dict:
                 # we can continue from this char
-                current_dict = current_dict[char]
+                curr_dict = curr_dict[char]
             else:
-                # we reset current_dict
-                current_dict = self.keyword_trie_dict
+                # we reset curr_dict
+                curr_dict = self.keyword_trie_dict
                 # skip to end of word
                 idy = idx + 1
                 while idy < sentence_len:
                     char = sentence[idy]
-                    current_word += orig_sentence[idy]
+                    curr_word += orig_sentence[idy]
                     if char not in self.non_word_boundaries:
                         break
                     idy += 1
                 idx = idy
-                new_sentence.append(current_word)
-                current_word = ''
+                new_sentence.append(curr_word)
+                curr_word = ''
                 current_white_space = ''
             # if we are end of sentence and have a sequence discovered
             if idx + 1 >= sentence_len:
-                if self._keyword in current_dict:
-                    sequence_found = current_dict[self._keyword]
-                    new_sentence.append(sequence_found)
+                if self._keyword in curr_dict:
+                    seq_found = curr_dict[self._keyword]
+                    new_sentence.append(seq_found)
                 else:
-                    new_sentence.append(current_word)
+                    new_sentence.append(curr_word)
             idx += 1
         return "".join(new_sentence)

--- a/flashtext/keyword.py
+++ b/flashtext/keyword.py
@@ -174,8 +174,12 @@ class KeywordProcessor(object):
                 if letter in current_dict:
                     character_trie_list.append((letter, current_dict))
                     current_dict = current_dict[letter]
+                else:
+                    # if character is not found, break out of the loop
+                    current_dict = None
+                    break
             # remove the characters from trie dict if there are no other keywords with them
-            if self._keyword in current_dict:
+            if current_dict and self._keyword in current_dict:
                 # we found a complete match for input keyword.
                 character_trie_list.append((self._keyword, current_dict))
                 character_trie_list.reverse()

--- a/flashtext/keyword.py
+++ b/flashtext/keyword.py
@@ -173,7 +173,7 @@ class KeywordProcessor(object):
                 if letter in current_dict:
                     character_trie_list.append((letter, current_dict))
                     current_dict = current_dict[letter]
-            # remove the charactes from trie dict if there are no other keywords with them
+            # remove the characters from trie dict if there are no other keywords with them
             if self._keyword in current_dict:
                 # we found a complete match for input keyword.
                 character_trie_list.append((self._keyword, current_dict))
@@ -410,7 +410,7 @@ class KeywordProcessor(object):
 
         Args:
             term_so_far : string
-                term built so far by adding all previous charactes
+                term built so far by adding all previous characters
             current_dict : dict
                 current recursive position in dictionary
 

--- a/flashtext/keyword.py
+++ b/flashtext/keyword.py
@@ -580,7 +580,7 @@ class KeywordProcessor(object):
         if not sentence:
             # if sentence is empty or none just return the same.
             return sentence
-        new_sentence = ''
+        new_sentence = []
         orig_sentence = sentence
         if not self.case_sensitive:
             sentence = sentence.lower()
@@ -639,17 +639,17 @@ class KeywordProcessor(object):
                             current_word = current_word_continued
                     current_dict = self.keyword_trie_dict
                     if longest_sequence_found:
-                        new_sentence += longest_sequence_found + current_white_space
+                        new_sentence.append(longest_sequence_found + current_white_space)
                         current_word = ''
                         current_white_space = ''
                     else:
-                        new_sentence += current_word
+                        new_sentence.append(current_word)
                         current_word = ''
                         current_white_space = ''
                 else:
                     # we reset current_dict
                     current_dict = self.keyword_trie_dict
-                    new_sentence += current_word
+                    new_sentence.append(current_word)
                     current_word = ''
                     current_white_space = ''
             elif char in current_dict:
@@ -667,15 +667,15 @@ class KeywordProcessor(object):
                         break
                     idy += 1
                 idx = idy
-                new_sentence += current_word
+                new_sentence.append(current_word)
                 current_word = ''
                 current_white_space = ''
             # if we are end of sentence and have a sequence discovered
             if idx + 1 >= sentence_len:
                 if self._keyword in current_dict:
                     sequence_found = current_dict[self._keyword]
-                    new_sentence += sequence_found
+                    new_sentence.append(sequence_found)
                 else:
-                    new_sentence += current_word
+                    new_sentence.append(current_word)
             idx += 1
-        return new_sentence
+        return "".join(new_sentence)

--- a/flashtext/keyword.py
+++ b/flashtext/keyword.py
@@ -1,5 +1,6 @@
 import os
 import string
+import io
 
 
 class KeywordProcessor(object):
@@ -283,7 +284,7 @@ class KeywordProcessor(object):
         """
         return self.__getitem__(word)
 
-    def add_keyword_from_file(self, keyword_file):
+    def add_keyword_from_file(self, keyword_file, encoding="utf-8"):
         """To add keywords from a file
 
         Args:
@@ -311,7 +312,7 @@ class KeywordProcessor(object):
         """
         if not os.path.isfile(keyword_file):
             raise IOError("Invalid file path {}".format(keyword_file))
-        with open(keyword_file)as f:
+        with io.open(keyword_file, encoding=encoding) as f:
             for line in f:
                 if '=>' in line:
                     keyword, clean_name = line.split('=>')

--- a/flashtext/keyword.py
+++ b/flashtext/keyword.py
@@ -1,7 +1,7 @@
 import os
 import string
 import io
-
+import nltk
 
 class KeywordProcessor(object):
     """KeywordProcessor

--- a/flashtext/keyword.py
+++ b/flashtext/keyword.py
@@ -670,5 +670,7 @@ class KeywordProcessor(object):
                 if self._keyword in current_dict:
                     sequence_found = current_dict[self._keyword]
                     new_sentence += sequence_found
+                else:
+                    new_sentence += current_word
             idx += 1
         return new_sentence

--- a/flashtext/keyword.py
+++ b/flashtext/keyword.py
@@ -499,12 +499,10 @@ class KeywordProcessor(object):
             sentence = sentence.lower()
         idx = 0
         sentences_with_keyword = []
-        seq_start_pos = 0
-        seq_end_pos = 0
-        reset_curr_dict = False
 
         def _helper(sentence, idx):
-            # print(idx)
+            reset_curr_dict = False
+            seq_start_pos = seq_end_pos = idx
             sentence_len = len(sentence)
             curr_dict = self.keyword_trie_dict
             while idx < sentence_len:
@@ -635,7 +633,7 @@ class KeywordProcessor(object):
             sentence = sentence.lower()
         curr_word = ''
         curr_dict = self.keyword_trie_dict
-        current_white_space = ''
+        curr_white_space = ''
         seq_end_pos = 0
         idx = 0
         sentence_len = len(sentence)
@@ -644,7 +642,7 @@ class KeywordProcessor(object):
             curr_word += orig_sentence[idx]
             # when we reach whitespace
             if char not in self.non_word_boundaries:
-                current_white_space = char
+                curr_white_space = char
                 # if end is present in curr_dict
                 if self._keyword in curr_dict or char in curr_dict:
                     # update longest sequence found
@@ -664,10 +662,10 @@ class KeywordProcessor(object):
                         while idy < sentence_len:
                             inner_char = sentence[idy]
                             curr_word_continued += orig_sentence[idy]
-                            if inner_char not in self.non_word_boundaries and
-                            self._keyword in curr_dict_continued:
+                            if inner_char not in self.non_word_boundaries \
+                            and self._keyword in curr_dict_continued:
                                 # update longest sequence found
-                                current_white_space = inner_char
+                                curr_white_space = inner_char
                                 longest_seq_found = curr_dict_continued[
                                                     self._keyword]
                                 seq_end_pos = idy
@@ -682,7 +680,7 @@ class KeywordProcessor(object):
                             # end of sentence reached.
                             if self._keyword in curr_dict_continued:
                                 # update longest sequence found
-                                current_white_space = ''
+                                curr_white_space = ''
                                 longest_seq_found = curr_dict_continued[
                                                     self._keyword]
                                 seq_end_pos = idy
@@ -693,19 +691,19 @@ class KeywordProcessor(object):
                     curr_dict = self.keyword_trie_dict
                     if longest_seq_found:
                         new_sentence.append(longest_seq_found +
-                                            current_white_space)
+                                            curr_white_space)
                         curr_word = ''
-                        current_white_space = ''
+                        curr_white_space = ''
                     else:
                         new_sentence.append(curr_word)
                         curr_word = ''
-                        current_white_space = ''
+                        curr_white_space = ''
                 else:
                     # we reset curr_dict
                     curr_dict = self.keyword_trie_dict
                     new_sentence.append(curr_word)
                     curr_word = ''
-                    current_white_space = ''
+                    curr_white_space = ''
             elif char in curr_dict:
                 # we can continue from this char
                 curr_dict = curr_dict[char]
@@ -723,7 +721,7 @@ class KeywordProcessor(object):
                 idx = idy
                 new_sentence.append(curr_word)
                 curr_word = ''
-                current_white_space = ''
+                curr_white_space = ''
             # if we are end of sentence and have a sequence discovered
             if idx + 1 >= sentence_len:
                 if self._keyword in curr_dict:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ class PyTest(Command):
         raise SystemExit(errno)
 
 name = 'flashtext'
-version = '2.5'
+version = '2.7'
 
 cmdclass = {'test': PyTest}
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ class PyTest(Command):
         raise SystemExit(errno)
 
 name = 'flashtext'
-version = '2.4'
+version = '2.5'
 
 cmdclass = {'test': PyTest}
 

--- a/test/keyword_extractor_test_cases.json
+++ b/test/keyword_extractor_test_cases.json
@@ -4,7 +4,7 @@
         "keyword_dict": {
             "Python": ["python"]
         },
-        "explaination": "Keyword at the end of the sentence.",
+        "explanation": "Keyword at the end of the sentence.",
         "keywords": ["Python"],
         "keywords_case_sensitive": ["Python"]
     },
@@ -13,7 +13,7 @@
         "keyword_dict": {
             "Python": ["python"]
         },
-        "explaination": "Keyword at the beginning of the sentence.",
+        "explanation": "Keyword at the beginning of the sentence.",
         "keywords": ["Python"],
         "keywords_case_sensitive": ["Python"]
     },
@@ -22,7 +22,7 @@
         "keyword_dict": {
             "Python": ["python"]
         },
-        "explaination": "Keyword before the end of the sentence.",
+        "explanation": "Keyword before the end of the sentence.",
         "keywords": ["Python"],
         "keywords_case_sensitive": ["Python"]
     },
@@ -32,7 +32,7 @@
             "Python": ["python"],
             "Java": ["java"]
         },
-        "explaination": "Multiple keywords in the end of the sentence.",
+        "explanation": "Multiple keywords in the end of the sentence.",
         "keywords": ["Python", "Java"],
         "keywords_case_sensitive": ["Python", "Java"]
     },
@@ -42,7 +42,7 @@
             "Python": ["python"],
             "Java": ["java"]
         },
-        "explaination": "Multiple keywords in the sentence with other word in between.",
+        "explanation": "Multiple keywords in the sentence with other word in between.",
         "keywords": ["Python", "Java"],
         "keywords_case_sensitive": ["Python", "Java"]
     },
@@ -51,7 +51,7 @@
         "keyword_dict": {
             "Python": ["python"]
         },
-        "explaination": "Single keyword in the sentence.",
+        "explanation": "Single keyword in the sentence.",
         "keywords": ["Python"],
         "keywords_case_sensitive": ["Python"]
     },
@@ -60,7 +60,7 @@
         "keyword_dict": {
             "Python": ["python"]
         },
-        "explaination": "Single keyword in the sentence with space prefix.",
+        "explanation": "Single keyword in the sentence with space prefix.",
         "keywords": ["Python"],
         "keywords_case_sensitive": ["Python"]
     },
@@ -69,7 +69,7 @@
         "keyword_dict": {
             "R": ["r"]
         },
-        "explaination": "Single char keyword at the end of the sentence.",
+        "explanation": "Single char keyword at the end of the sentence.",
         "keywords": ["R"],
         "keywords_case_sensitive": ["R"]
     },
@@ -78,7 +78,7 @@
         "keyword_dict": {
             "R": ["r"]
         },
-        "explaination": "Single char keyword at the beginning of the sentence.",
+        "explanation": "Single char keyword at the beginning of the sentence.",
         "keywords": ["R"],
         "keywords_case_sensitive": ["R"]
     },
@@ -87,7 +87,7 @@
         "keyword_dict": {
             "R": ["r"]
         },
-        "explaination": "Single char keyword before the end of the sentence.",
+        "explanation": "Single char keyword before the end of the sentence.",
         "keywords": ["R"],
         "keywords_case_sensitive": []
     },
@@ -97,7 +97,7 @@
             "R": ["r"],
             "Java": ["java"]
         },
-        "explaination": "Multiple keywords in the end of the sentence.",
+        "explanation": "Multiple keywords in the end of the sentence.",
         "keywords": ["R", "Java"],
         "keywords_case_sensitive": ["Java"]
     },
@@ -107,7 +107,7 @@
             "R": ["R"],
             "Java": ["java"]
         },
-        "explaination": "Multiple keywords in the sentence with other word in between.",
+        "explanation": "Multiple keywords in the sentence with other word in between.",
         "keywords": ["R", "Java"],
         "keywords_case_sensitive": ["R", "Java"]
     },
@@ -116,7 +116,7 @@
         "keyword_dict": {
             "R": ["r"]
         },
-        "explaination": "Single character keyword in the sentence.",
+        "explanation": "Single character keyword in the sentence.",
         "keywords": ["R"],
         "keywords_case_sensitive": []
     },
@@ -125,7 +125,7 @@
         "keyword_dict": {
             "R": ["R"]
         },
-        "explaination": "Single character keyword in the sentence with space prefix.",
+        "explanation": "Single character keyword in the sentence with space prefix.",
         "keywords": ["R"],
         "keywords_case_sensitive": ["R"]
     },
@@ -134,7 +134,7 @@
         "keyword_dict": {
             "Distributed Super Computing": ["distributed super computing"]
         },
-        "explaination": "Multi word Keyword at the end of the sentence.",
+        "explanation": "Multi word Keyword at the end of the sentence.",
         "keywords": ["Distributed Super Computing"],
         "keywords_case_sensitive": ["Distributed Super Computing"]
     },
@@ -143,7 +143,7 @@
         "keyword_dict": {
             "Distributed Super Computing": ["distributed super computing"]
         },
-        "explaination": "Multi word Keyword at the beginning of the sentence.",
+        "explanation": "Multi word Keyword at the beginning of the sentence.",
         "keywords": ["Distributed Super Computing"],
         "keywords_case_sensitive": ["Distributed Super Computing"]
     },
@@ -152,7 +152,7 @@
         "keyword_dict": {
             "Distributed Super Computing": ["distributed super computing"]
         },
-        "explaination": "Multi word Keyword before the end of the sentence.",
+        "explanation": "Multi word Keyword before the end of the sentence.",
         "keywords": ["Distributed Super Computing"],
         "keywords_case_sensitive": ["Distributed Super Computing"]
     },
@@ -162,7 +162,7 @@
             "Distributed Super Computing": ["distributed super computing"],
             "Java": ["java"]
         },
-        "explaination": "Multi word Keyword at the end of the sentence.",
+        "explanation": "Multi word Keyword at the end of the sentence.",
         "keywords": ["Distributed Super Computing", "Java"],
         "keywords_case_sensitive": ["Distributed Super Computing", "Java"]
     },
@@ -172,7 +172,7 @@
             "Distributed Super Computing": ["distributed super computing"],
             "Java": ["java programing"]
         },
-        "explaination": "Multiple Multi word Keyword at the end of the sentence.",
+        "explanation": "Multiple Multi word Keyword at the end of the sentence.",
         "keywords": ["Distributed Super Computing", "Java"],
         "keywords_case_sensitive": ["Distributed Super Computing", "Java"]
     },
@@ -182,7 +182,7 @@
             "Distributed Super Computing": ["distributed super computing"],
             "Java": ["java"]
         },
-        "explaination": "Multiple keywords in the sentence with other word in between.",
+        "explanation": "Multiple keywords in the sentence with other word in between.",
         "keywords": ["Distributed Super Computing", "Java"],
         "keywords_case_sensitive": ["Distributed Super Computing", "Java"]
     },
@@ -191,7 +191,7 @@
         "keyword_dict": {
             "Distributed Super Computing": ["distributed super computing"]
         },
-        "explaination": "Single Multi word Keyword in the sentence.",
+        "explanation": "Single Multi word Keyword in the sentence.",
         "keywords": ["Distributed Super Computing"],
         "keywords_case_sensitive": ["Distributed Super Computing"]
     },
@@ -200,7 +200,7 @@
         "keyword_dict": {
             "Distributed Super Computing": ["distributed super computing"]
         },
-        "explaination": "Single Multi word Keyword in the sentence with space prefix.",
+        "explanation": "Single Multi word Keyword in the sentence with space prefix.",
         "keywords": ["Distributed Super Computing"],
         "keywords_case_sensitive": ["Distributed Super Computing"]
     },
@@ -209,7 +209,7 @@
         "keyword_dict": {
             "Distributed Super Computing": ["distributed super computing"]
         },
-        "explaination": "Multi word Keyword twice",
+        "explanation": "Multi word Keyword twice",
         "keywords": ["Distributed Super Computing", "Distributed Super Computing"],
         "keywords_case_sensitive": ["Distributed Super Computing", "Distributed Super Computing"]
     },
@@ -218,7 +218,7 @@
         "keyword_dict": {
             "Distributed Super Computing": ["distributed super computing"]
         },
-        "explaination": "Multi word Keyword partial then complete.",
+        "explanation": "Multi word Keyword partial then complete.",
         "keywords": ["Distributed Super Computing"],
         "keywords_case_sensitive": ["Distributed Super Computing"]
     },
@@ -228,7 +228,7 @@
             "Distributed Super Computing": ["distributed super computing"],
             "Java": ["java"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computing", "Java"],
         "keywords_case_sensitive": ["Distributed Super Computing", "Java"]
     },
@@ -238,7 +238,7 @@
             "Distributed Super Computing": ["distributed super computing"],
             "Distributed Super Computing Institute": ["distributed super computing institute"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computing Institute"],
         "keywords_case_sensitive": ["Distributed Super Computing Institute"]
     },
@@ -248,7 +248,7 @@
             "Distributed Super Computing": ["distributed super computing"],
             "Distributed Super Computing Institute": ["distributed super computing institute"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computing"],
         "keywords_case_sensitive": ["Distributed Super Computing"]
     },
@@ -259,7 +259,7 @@
             "Distributed Super Computing Institute": ["distributed super computing institute"],
             "Java": ["java"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computing", "Java"],
         "keywords_case_sensitive": ["Distributed Super Computing", "Java"]
     },
@@ -270,7 +270,7 @@
             "Distributed Super Computing Institute": ["distributed super computing institute"],
             "Java": ["java"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computing Institute", "Java"],
         "keywords_case_sensitive": ["Distributed Super Computing Institute", "Java"]
     },
@@ -281,7 +281,7 @@
             "Distributed Super Computing Institute": ["distributed super computing institute"],
             "Java": ["java"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computing Institute", "Java"],
         "keywords_case_sensitive": ["Distributed Super Computing Institute", "Java"]
     },
@@ -292,7 +292,7 @@
             "Distributed Super Computing Institute": ["distributed super computing institute"],
             "R": ["r"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computing", "R"],
         "keywords_case_sensitive": ["Distributed Super Computing", "R"]
     },
@@ -303,7 +303,7 @@
             "Distributed Super Computing Institute": ["distributed super computing institute"],
             "R": ["r"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computing Institute", "R"],
         "keywords_case_sensitive": ["Distributed Super Computing Institute", "R"]
     },
@@ -314,7 +314,7 @@
             "Distributed Super Computing Institute": ["distributed super computing institute"],
             "R": ["r"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computing Institute", "R"],
         "keywords_case_sensitive": ["Distributed Super Computing Institute", "R"]
     },
@@ -324,7 +324,7 @@
             "Distributed Programing": ["distributed programing"],
             "Pronoun Game": ["pronoun game"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Pronoun Game"],
         "keywords_case_sensitive": ["Pronoun Game"]
     },
@@ -334,7 +334,7 @@
             "Distributed Super Computer": ["distributed super computer"],
             "Computer Game": ["computer game"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Distributed Super Computer"],
         "keywords_case_sensitive": ["Distributed Super Computer"]
     },
@@ -344,7 +344,7 @@
             "Distributed Super Company": ["distributed super company"],
             "Computer Game": ["computer game"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Computer Game"],
         "keywords_case_sensitive": ["Computer Game"]
     },
@@ -355,7 +355,7 @@
             "Super Computer": ["super computer"],
             "Computer Game": ["computer game"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Super Computer"],
         "keywords_case_sensitive": ["Super Computer"]
     },
@@ -366,7 +366,7 @@
             "Super Computer": ["super computer"],
             "Computer Game": ["computer game"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": [],
         "keywords_case_sensitive": []
     },
@@ -376,7 +376,7 @@
             "Computer Game": ["computer game"],
             "Computer Game Development": ["computer game development"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Computer Game Development"],
         "keywords_case_sensitive": ["Computer Game Development"]
     },
@@ -386,7 +386,7 @@
             "Computer Gaming": ["computer gaming"],
             "Computer Game Development": ["computer game development"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["Computer Game Development"],
         "keywords_case_sensitive": ["Computer Game Development"]
     },
@@ -395,7 +395,7 @@
         "keyword_dict": {
             ".NET": [".net"]
         },
-        "explaination": "keyword with special character",
+        "explanation": "keyword with special character",
         "keywords": [".NET"],
         "keywords_case_sensitive": [".NET"]
     },
@@ -404,7 +404,7 @@
         "keyword_dict": {
             "Cpp": ["c++"]
         },
-        "explaination": "keyword with special character",
+        "explanation": "keyword with special character",
         "keywords": ["Cpp"],
         "keywords_case_sensitive": ["Cpp"]
     },
@@ -413,7 +413,7 @@
         "keyword_dict": {
             "Python": ["python."]
         },
-        "explaination": "Ending with special character",
+        "explanation": "Ending with special character",
         "keywords": ["Python"],
         "keywords_case_sensitive": ["Python"]
     },
@@ -422,7 +422,7 @@
         "keyword_dict": {
             "Python": ["python"]
         },
-        "explaination": "Ending with special character",
+        "explanation": "Ending with special character",
         "keywords": ["Python"],
         "keywords_case_sensitive": ["Python"]
     },
@@ -431,7 +431,7 @@
         "keyword_dict": {
             "Python": ["python prog"]
         },
-        "explaination": "Negative test case",
+        "explanation": "Negative test case",
         "keywords": [],
         "keywords_case_sensitive": []
     },
@@ -443,7 +443,7 @@
             "Institute": ["institute"],
             "Distributed Super Computing": ["distributed super computing"]
         },
-        "explaination": "Negative test case",
+        "explanation": "Negative test case",
         "keywords": ["Distributed Super Computing", "Institute", "Java"],
         "keywords_case_sensitive": ["Distributed Super Computing", "Institute", "Java"]
     },
@@ -454,7 +454,7 @@
             "XBP1s": ["XBP1s"],
             "UPR": ["upr"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["IRE1", "XBP1s", "UPR"],
         "keywords_case_sensitive": ["IRE1", "XBP1s"]
     },
@@ -464,7 +464,7 @@
             "spring framework": ["spring", "spring framework"],
             "framework": ["framework"]
         },
-        "explaination": "",
+        "explanation": "",
         "keywords": ["spring framework"],
         "keywords_case_sensitive": ["spring framework"]
     }

--- a/test/keyword_extractor_test_cases.json
+++ b/test/keyword_extractor_test_cases.json
@@ -9,6 +9,15 @@
         "keywords_case_sensitive": ["Python"]
     },
     {
+        "sentence": "I like python",
+        "keyword_dict": {
+            "Pythonizer": ["pythonizer"]
+        },
+        "explanation": "Incomplete keyword at the end of the sentence.",
+        "keywords": [],
+        "keywords_case_sensitive": []
+    },
+    {
         "sentence": "python I like",
         "keyword_dict": {
             "Python": ["python"]

--- a/test/keyword_remover_test_cases.json
+++ b/test/keyword_remover_test_cases.json
@@ -101,5 +101,16 @@
         },
         "keywords": ["spring framework"],
         "keywords_case_sensitive": ["spring framework"]
+    },
+    {
+        "sentence": "computer vision",
+        "keyword_dict": {
+            "computer vision": ["computer vision"]
+        },
+        "remove_keyword_dict": {
+            "computer vision center": ["computer vision center"]
+        },
+        "keywords": ["computer vision"],
+        "keywords_case_sensitive": ["computer vision"]
     }
 ]

--- a/test/test_kp_exceptions.py
+++ b/test/test_kp_exceptions.py
@@ -1,0 +1,54 @@
+from collections import defaultdict
+from flashtext import KeywordProcessor
+import logging
+import unittest
+import pytest
+import json
+import re
+
+logger = logging.getLogger(__name__)
+
+
+class TestKPExceptions(unittest.TestCase):
+    def setUp(self):
+        logger.info("Starting...")
+
+    def tearDown(self):
+        logger.info("Ending.")
+
+    def test_iterator_NotImplementedError(self):
+        keyword_processor = KeywordProcessor()
+        keyword_processor.add_keyword('j2ee', 'Java')
+        keyword_processor.add_keyword('colour', 'color')
+        keyword_processor.get_all_keywords()
+        with pytest.raises(NotImplementedError):
+            for value in keyword_processor:
+                pass
+
+    def test_add_keyword_file_missing(self):
+        keyword_processor = KeywordProcessor()
+        with pytest.raises(IOError):
+            keyword_processor.add_keyword_from_file('missing_file')
+
+    def test_add_keyword_file_missing(self):
+        keyword_processor = KeywordProcessor()
+        keyword_dict = {
+            "java": "java_2e",
+            "product management": "product manager"
+        }
+        with pytest.raises(AttributeError):
+            keyword_processor.add_keywords_from_dict(keyword_dict)
+
+    def test_empty_string(self):
+        keyword_processor = KeywordProcessor()
+        keyword_dict = {
+            "java": "java_2e",
+            "product management": "product manager"
+        }
+        self.assertEqual(keyword_processor.extract_keywords(""), [],
+                         "new_sentence don't match the expected result")
+        self.assertEqual(keyword_processor.replace_keywords(""), "",
+                         "new_sentence don't match the expected result")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_kp_exceptions.py
+++ b/test/test_kp_exceptions.py
@@ -30,7 +30,13 @@ class TestKPExceptions(unittest.TestCase):
         with pytest.raises(IOError):
             keyword_processor.add_keyword_from_file('missing_file')
 
-    def test_add_keyword_file_missing(self):
+    def test_add_keyword_from_list(self):
+        keyword_processor = KeywordProcessor()
+        keyword_list = "java"
+        with pytest.raises(AttributeError):
+            keyword_processor.add_keywords_from_list(keyword_list)
+
+    def test_add_keyword_from_dictionary(self):
         keyword_processor = KeywordProcessor()
         keyword_dict = {
             "java": "java_2e",
@@ -38,6 +44,21 @@ class TestKPExceptions(unittest.TestCase):
         }
         with pytest.raises(AttributeError):
             keyword_processor.add_keywords_from_dict(keyword_dict)
+
+    def test_remove_keyword_from_list(self):
+        keyword_processor = KeywordProcessor()
+        keyword_list = "java"
+        with pytest.raises(AttributeError):
+            keyword_processor.remove_keywords_from_list(keyword_list)
+
+    def test_remove_keyword_from_dictionary(self):
+        keyword_processor = KeywordProcessor()
+        keyword_dict = {
+            "java": "java_2e",
+            "product management": "product manager"
+        }
+        with pytest.raises(AttributeError):
+            keyword_processor.remove_keywords_from_dict(keyword_dict)
 
     def test_empty_string(self):
         keyword_processor = KeywordProcessor()

--- a/test/test_kp_extract_span.py
+++ b/test/test_kp_extract_span.py
@@ -1,0 +1,53 @@
+from flashtext import KeywordProcessor
+import logging
+import unittest
+import json
+
+logger = logging.getLogger(__name__)
+
+
+class TestKPExtractorSpan(unittest.TestCase):
+    def setUp(self):
+        logger.info("Starting...")
+        with open('test/keyword_extractor_test_cases.json') as f:
+            self.test_cases = json.load(f)
+
+    def tearDown(self):
+        logger.info("Ending.")
+
+    def test_extract_keywords(self):
+        """For each of the test case initialize a new KeywordProcessor.
+        Add the keywords the test case to KeywordProcessor.
+        Extract keywords and check if they match the expected result for the test case.
+
+        """
+        for test_id, test_case in enumerate(self.test_cases):
+            keyword_processor = KeywordProcessor()
+            for key in test_case['keyword_dict']:
+                keyword_processor.add_keywords_from_list(test_case['keyword_dict'][key])
+            keywords_extracted = keyword_processor.extract_keywords(test_case['sentence'], span_info=True)
+            for kwd in keywords_extracted:
+                # returned keyword lowered should match the sapn from sentence
+                self.assertEqual(
+                    kwd[0].lower(), test_case['sentence'].lower()[kwd[1]:kwd[2]],
+                    "keywords span don't match the expected results for test case: {}".format(test_id))
+
+    def test_extract_keywords_case_sensitive(self):
+        """For each of the test case initialize a new KeywordProcessor.
+        Add the keywords the test case to KeywordProcessor.
+        Extract keywords and check if they match the expected result for the test case.
+
+        """
+        for test_id, test_case in enumerate(self.test_cases):
+            keyword_processor = KeywordProcessor(case_sensitive=True)
+            for key in test_case['keyword_dict']:
+                keyword_processor.add_keywords_from_list(test_case['keyword_dict'][key])
+            keywords_extracted = keyword_processor.extract_keywords(test_case['sentence'], span_info=True)
+            for kwd in keywords_extracted:
+                # returned keyword should match the sapn from sentence
+                self.assertEqual(
+                    kwd[0], test_case['sentence'][kwd[1]:kwd[2]],
+                    "keywords span don't match the expected results for test case: {}".format(test_id))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_kp_get_all_keywords.py
+++ b/test/test_kp_get_all_keywords.py
@@ -1,0 +1,29 @@
+from collections import defaultdict
+from flashtext import KeywordProcessor
+import logging
+import unittest
+import json
+import re
+
+logger = logging.getLogger(__name__)
+
+
+class TestKPKeywords(unittest.TestCase):
+    def setUp(self):
+        logger.info("Starting...")
+
+    def tearDown(self):
+        logger.info("Ending.")
+
+    def test_list_loading(self):
+        keyword_processor = KeywordProcessor()
+        keyword_processor.add_keyword('j2ee', 'Java')
+        keyword_processor.add_keyword('onGoing', 'rendom')
+        keyword_processor.get_all_keywords()
+        self.assertEqual(keyword_processor.get_all_keywords(),
+                         {'j2ee': 'Java', 'ongoing': 'rendom'},
+                         "get_all_keywords didn't match expected results.")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_kp_get_all_keywords.py
+++ b/test/test_kp_get_all_keywords.py
@@ -15,7 +15,7 @@ class TestKPGetAllKeywords(unittest.TestCase):
     def tearDown(self):
         logger.info("Ending.")
 
-    def test_list_loading(self):
+    def test_get_all_keywords(self):
         keyword_processor = KeywordProcessor()
         keyword_processor.add_keyword('j2ee', 'Java')
         keyword_processor.add_keyword('colour', 'color')

--- a/test/test_kp_len.py
+++ b/test/test_kp_len.py
@@ -30,13 +30,13 @@ class TestKPLen(unittest.TestCase):
             kp_len = len(keyword_processor)
             kp_len_expected = sum([len(values) for key, values in test_case['keyword_dict'].items()])
             self.assertEqual(kp_len, kp_len_expected,
-                             "keyword processor length doesn't matches".format(test_id))
+                             "keyword processor length doesn't match".format(test_id))
             keyword_processor.remove_keywords_from_dict(test_case['remove_keyword_dict'])
             # check length
             kp_len = len(keyword_processor)
             kp_len_decreased = sum([len(values) for key, values in test_case['remove_keyword_dict'].items()])
             self.assertEqual(kp_len, kp_len_expected - kp_len_decreased,
-                             "keyword processor length doesn't matche for Text ID {}".format(test_id))
+                             "keyword processor length doesn't match for Text ID {}".format(test_id))
 
     def test_remove_keywords_dictionary_len(self):
         """For each of the test case initialize a new KeywordProcessor.
@@ -61,6 +61,6 @@ class TestKPLen(unittest.TestCase):
             keyword_processor_two.add_keywords_from_dict(new_dictionary)
             kp_len_two = len(keyword_processor_two)
             self.assertEqual(kp_len, kp_len_two,
-                             "keyword processor length doesn't matche for Text ID {}".format(test_id))
+                             "keyword processor length doesn't match for Text ID {}".format(test_id))
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_kp_len.py
+++ b/test/test_kp_len.py
@@ -4,8 +4,12 @@ import logging
 import unittest
 import json
 import re
+import sys
 
 logger = logging.getLogger(__name__)
+logger.level = logging.DEBUG
+stream_handler = logging.StreamHandler(sys.stdout)
+logger.addHandler(stream_handler)
 
 
 class TestKPLen(unittest.TestCase):
@@ -16,27 +20,6 @@ class TestKPLen(unittest.TestCase):
 
     def tearDown(self):
         logger.info("Ending.")
-
-    def test_remove_keywords_len(self):
-        """For each of the test case initialize a new KeywordProcessor.
-        Add the keywords the test case to KeywordProcessor.
-        Remove the keywords in remove_keyword_dict
-        Extract keywords and check if they match the expected result for the test case.
-        """
-        for test_id, test_case in enumerate(self.test_cases):
-            keyword_processor = KeywordProcessor()
-            keyword_processor.add_keywords_from_dict(test_case['keyword_dict'])
-            # check length
-            kp_len = len(keyword_processor)
-            kp_len_expected = sum([len(values) for key, values in test_case['keyword_dict'].items()])
-            self.assertEqual(kp_len, kp_len_expected,
-                             "keyword processor length doesn't match".format(test_id))
-            keyword_processor.remove_keywords_from_dict(test_case['remove_keyword_dict'])
-            # check length
-            kp_len = len(keyword_processor)
-            kp_len_decreased = sum([len(values) for key, values in test_case['remove_keyword_dict'].items()])
-            self.assertEqual(kp_len, kp_len_expected - kp_len_decreased,
-                             "keyword processor length doesn't match for Text ID {}".format(test_id))
 
     def test_remove_keywords_dictionary_len(self):
         """For each of the test case initialize a new KeywordProcessor.

--- a/test/test_kp_term_in_kp.py
+++ b/test/test_kp_term_in_kp.py
@@ -29,6 +29,29 @@ class TestKPDictionaryLikeFeatures(unittest.TestCase):
         self.assertEqual(keyword_processor['Test'],
                          None,
                          "get_keyword didn't return expected Keyword")
+        self.assertTrue('colour' in keyword_processor,
+                        "get_keyword didn't return expected Keyword")
+        self.assertFalse('Test' in keyword_processor,
+                         "get_keyword didn't return expected Keyword")
+
+    def test_term_in_dictionary_case_sensitive(self):
+        keyword_processor = KeywordProcessor(case_sensitive=True)
+        keyword_processor.add_keyword('j2ee', 'Java')
+        keyword_processor.add_keyword('colour', 'color')
+        keyword_processor.get_keyword('j2ee')
+        self.assertEqual(keyword_processor.get_keyword('j2ee'),
+                         'Java',
+                         "get_keyword didn't return expected Keyword")
+        self.assertEqual(keyword_processor['colour'],
+                         'color',
+                         "get_keyword didn't return expected Keyword")
+        self.assertEqual(keyword_processor['J2ee'],
+                         None,
+                         "get_keyword didn't return expected Keyword")
+        self.assertTrue('colour' in keyword_processor,
+                        "get_keyword didn't return expected Keyword")
+        self.assertFalse('Colour' in keyword_processor,
+                         "get_keyword didn't return expected Keyword")
 
 
 if __name__ == '__main__':

--- a/test/test_kp_term_in_kp.py
+++ b/test/test_kp_term_in_kp.py
@@ -8,7 +8,7 @@ import re
 logger = logging.getLogger(__name__)
 
 
-class TestKPGetAllKeywords(unittest.TestCase):
+class TestKPTermInKP(unittest.TestCase):
     def setUp(self):
         logger.info("Starting...")
 
@@ -18,10 +18,10 @@ class TestKPGetAllKeywords(unittest.TestCase):
     def test_list_loading(self):
         keyword_processor = KeywordProcessor()
         keyword_processor.add_keyword('j2ee', 'Java')
-        keyword_processor.add_keyword('colour', 'color')
+        keyword_processor.add_keyword('onGoing', 'rendom')
         keyword_processor.get_all_keywords()
         self.assertEqual(keyword_processor.get_all_keywords(),
-                         {'colour': 'color', 'j2ee': 'Java'},
+                         {'j2ee': 'Java', 'ongoing': 'rendom'},
                          "get_all_keywords didn't match expected results.")
 
 

--- a/test/test_kp_term_in_kp.py
+++ b/test/test_kp_term_in_kp.py
@@ -8,21 +8,27 @@ import re
 logger = logging.getLogger(__name__)
 
 
-class TestKPTermInKP(unittest.TestCase):
+class TestKPDictionaryLikeFeatures(unittest.TestCase):
     def setUp(self):
         logger.info("Starting...")
 
     def tearDown(self):
         logger.info("Ending.")
 
-    def test_list_loading(self):
+    def test_term_in_dictionary(self):
         keyword_processor = KeywordProcessor()
         keyword_processor.add_keyword('j2ee', 'Java')
-        keyword_processor.add_keyword('onGoing', 'rendom')
-        keyword_processor.get_all_keywords()
-        self.assertEqual(keyword_processor.get_all_keywords(),
-                         {'j2ee': 'Java', 'ongoing': 'rendom'},
-                         "get_all_keywords didn't match expected results.")
+        keyword_processor.add_keyword('colour', 'color')
+        keyword_processor.get_keyword('j2ee')
+        self.assertEqual(keyword_processor.get_keyword('j2ee'),
+                         'Java',
+                         "get_keyword didn't return expected Keyword")
+        self.assertEqual(keyword_processor['colour'],
+                         'color',
+                         "get_keyword didn't return expected Keyword")
+        self.assertEqual(keyword_processor['Test'],
+                         None,
+                         "get_keyword didn't return expected Keyword")
 
 
 if __name__ == '__main__':

--- a/test/test_remove_keywords.py
+++ b/test/test_remove_keywords.py
@@ -31,6 +31,21 @@ class TestKeywordRemover(unittest.TestCase):
             self.assertEqual(keywords_extracted, test_case['keywords'],
                              "keywords_extracted don't match the expected results for test case: {}".format(test_id))
 
+    def test_remove_keywords_using_list(self):
+        """For each of the test case initialize a new KeywordProcessor.
+        Add the keywords the test case to KeywordProcessor.
+        Remove the keywords in remove_keyword_dict
+        Extract keywords and check if they match the expected result for the test case.
+        """
+        for test_id, test_case in enumerate(self.test_cases):
+            keyword_processor = KeywordProcessor()
+            keyword_processor.add_keywords_from_dict(test_case['keyword_dict'])
+            for key in test_case['remove_keyword_dict']:
+                keyword_processor.remove_keywords_from_list(test_case['remove_keyword_dict'][key])
+            keywords_extracted = keyword_processor.extract_keywords(test_case['sentence'])
+            self.assertEqual(keywords_extracted, test_case['keywords'],
+                             "keywords_extracted don't match the expected results for test case: {}".format(test_id))
+
     def test_remove_keywords_dictionary_compare(self):
         """For each of the test case initialize a new KeywordProcessor.
         Add the keywords the test case to KeywordProcessor.


### PR DESCRIPTION
While searching for a `search` utility, I found FlashText . 
However, instead of returning only the keyword matches and the index span info, this PR focuses on returning the sentences which contain the keyword.
The approach followed is to sentence tokenize the corpus using NLTK's `sent_tokenize`.
This is configurable with `fetch_sent` flag in `extract_keywords(<corpus>, <span_info_flag>, <fetch_sent>)` which is `False` by default.
Also, `keyword.py` is made entirely PEP8 compliant.

P.S: Please run `pip install nltk` 