### PR TITLE
Fix to extract Asian words not separated by space

### DIFF
--- a/flashtext/keyword.py
+++ b/flashtext/keyword.py
@@ -524,6 +524,7 @@ class KeywordProcessor(object):
                     current_dict = self.keyword_trie_dict
                     if longest_sequence_found:
                         keywords_extracted.append((longest_sequence_found, sequence_start_pos, idx))
+                        idx -= 1
                     reset_current_dict = True
                 else:
                     # we reset current_dict


### PR DESCRIPTION
The Korean language if occasionally written without spaces separating the words. This `PR` aims to handle words that are in the dictionary, but not all entirely extracted due to being "stuck together" in the input text.

```
kp = flashtext.KeywordProcessor()
kp.add_keyword('한국')
kp.add_keyword('전력')
kp.add_keyword('공사')

kp.extract_keywords('한국전력공사')
```

Expected output:
`['한국', '전력', '공사']`

Real output:
`['한국', '공사']`